### PR TITLE
Releasing v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,30 @@
+v0.5.0
+- Adding `_` suggesting private methods and functions:
+  - `FuncGen` methods
+    - `_check_pyvisa_status()`
+    - `_initialise_model_properties()`
+    - `_normalise_to_waveform()`
+    - `_verify_waveform()`
+    - `_check_arb_waveform_length()`
+    - `_check_arb_waveform_type_and_range()`
+    - `_impedance_dependent_limit()`
+    - `_spawn_channel()`
+- `FuncGen` attributes
+    - `_id`
+    - `_inst`
+    - `address` -> `_visa_address`
+    - `_arbitrary_waveform_length`
+    - `_arbitrary_waveform_resolution`
+    - `_override_compatibility`
+    - `_timeout`
+    - `_maker`
+    - `_serial`
+    - `_model`
+  - `FuncGenChannel`
+    - `_source`
+    - `state_str` -> `_state_to_str`
+
+
 v0.4.0
 - Ensuring compatibility with `pyvisa v11.1`: ([issue #2](https://github.com/asvela/tektronix-func-gen/issues/2))
   - PYVISAs `write()` does not return the status code anymore, so the module is modified accordingly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,56 +1,62 @@
-v0.5.0
-- Adding `_` suggesting private methods and functions:
-  - `FuncGen` methods
-    - `_check_pyvisa_status()`
-    - `_initialise_model_properties()`
-    - `_normalise_to_waveform()`
-    - `_verify_waveform()`
-    - `_check_arb_waveform_length()`
-    - `_check_arb_waveform_type_and_range()`
-    - `_impedance_dependent_limit()`
-    - `_spawn_channel()`
-- `FuncGen` attributes
-    - `_id`
-    - `_inst`
-    - `address` -> `_visa_address`
-    - `_arbitrary_waveform_length`
-    - `_arbitrary_waveform_resolution`
-    - `_override_compatibility`
-    - `_timeout`
-    - `_maker`
-    - `_serial`
-    - `_model`
-  - `FuncGenChannel`
-    - `_source`
-    - `state_str` -> `_state_to_str`
+v0.5
+  - Adding `_` suggesting private methods and functions:
+    - `FuncGen` methods
+      - `_check_pyvisa_status()`
+      - `_initialise_model_properties()`
+      - `_normalise_to_waveform()`
+      - `_verify_waveform()`
+      - `_check_arb_waveform_length()`
+      - `_check_arb_waveform_type_and_range()`
+      - `_impedance_dependent_limit()`
+      - `_spawn_channel()`
+  - `FuncGen` attributes
+      - `_id`
+      - `_inst`
+      - `address` -> `_visa_address`
+      - `_arbitrary_waveform_length`
+      - `_arbitrary_waveform_resolution`
+      - `_override_compatibility`
+      - `_timeout`
+      - `_maker`
+      - `_serial`
+      - `_model`
+    - `FuncGenChannel`
+      - `_source`
+      - `state_str` -> `_state_to_str`
+- Moving `SI_prefix_to_factor()` out of the class, now a private module function
+- Moving to `f""`-strings from `"".format()`
 
-
-v0.4.0
-- Ensuring compatibility with `pyvisa v11.1`: ([issue #2](https://github.com/asvela/tektronix-func-gen/issues/2))
-  - PYVISAs `write()` does not return the status code anymore, so the module is modified accordingly
-  - not necessary to have an empty query after `write_binary_values()` in `set_custom_waveform()`
-- Added `check_pyvisa_status()`, now checking status for both queries and writes
-- Bug fixes for `set_frequency()` and `set_offset()` that were previously not taking into account the unit when calculating if it was within the limits
+v0.4
+  - Ensuring compatibility with `pyvisa v11.1`: ([issue #2](https://github.com/asvela/tektronix-func-gen/issues/2))
+    - PYVISAs `write()` does not return the status code anymore, so the module
+      is modified accordingly
+    - not necessary to have an empty query after `write_binary_values()`
+      in `set_custom_waveform()`
+  - Added `check_pyvisa_status()`, now checking status for both queries and writes
+  - Bug fixes for `set_frequency()` and `set_offset()` that were previously
+    not taking into account the unit when calculating if it was within the limits
 
 v0.3.1
-- Added note about known issue with TekVISA
-- Added more details about flat waveform offset through custom waveform workaround
+  - Added note about known issue with TekVISA
+  - Added more details about flat waveform offset through custom waveform workaround
 
 v0.3.0
-- Made SI_prefix_to_factor a staticmethod in FuncGen rather than module-level function
-- Added note about constant/flat function
+  - Made SI_prefix_to_factor a staticmethod in FuncGen rather than module-level function
+  - Added note about constant/flat function
 
 v0.2
-- More PEP8 compliant:
-  - `func_gen()` -> `FuncGen()`
-  - `func_gen_channel()` -> `FuncGenChannel()`
-  - All lines < 100 characters (mostly < 80)
-- No more `enable`/`disable_frequency_lock()`, now `set_frequency_lock()`
-- Settings dictionary now contains tuples of value and unit, e.g. `settings = {"amplitude": (3, "Vpp"), ..}`
-- Implemented `set_settings()` in both `FuncGen` and `FuncGenChannel` that takes a settings dictionary as input
-- `get`/`set_output()` links to `get`/`set_output_state()`
-- More examples
-- Expanded README
+  - More PEP8 compliant:
+    - `func_gen()` -> `FuncGen()`
+    - `func_gen_channel()` -> `FuncGenChannel()`
+    - All lines < 100 characters (mostly < 80)
+  - No more `enable`/`disable_frequency_lock()`, now `set_frequency_lock()`
+  - Settings dictionary now contains tuples of value and unit, e.g.
+    `settings = {"amplitude": (3, "Vpp"), ..}`
+  - Implemented `set_settings()` in both `FuncGen` and `FuncGenChannel` that
+    takes a settings dictionary as input
+  - `get`/`set_output()` links to `get`/`set_output_state()`
+  - More examples
+  - Expanded README
 
 v0.1
-- First release
+  - First release

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright 2020 Andreas Svela
+Copyright 2021 Andreas Svela
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 ## Tektronix arbitrary function generator control
 
+[![CodeFactor Grade](https://img.shields.io/codefactor/grade/github/asvela/tektronix-func-gen?style=flat-square)](https://www.codefactor.io/repository/github/asvela/tektronix-func-gen)
+[![MIT License](https://img.shields.io/github/license/asvela/dlc-control?style=flat-square)](https://github.com/asvela/dlc-control/blob/main/LICENSE)
+
 API documentation available [here](https://asvela.github.io/tektronix-func-gen/),
 or in the repository [docs/index.html](docs/index.html). (To build the documentation
 yourself use [pdoc3](https://pdoc3.github.io/pdoc/) and run

--- a/README.md
+++ b/README.md
@@ -1,27 +1,37 @@
-# Tektronix arbitrary function generator control through PyVISA
+## Tektronix arbitrary function generator control
 
-v0.4.0 // Nov 2020
+API documentation available [here](https://asvela.github.io/tektronix-func-gen/),
+or in the repository [docs/index.html](docs/index.html). (To build the documentation
+yourself use [pdoc3](https://pdoc3.github.io/pdoc/) and run
+`$ python3 pdoc --html -o ./docs/ tektronix_func_gen`.)
 
-API documentation can be found at [GitHub pages](https://asvela.github.io/tektronix-func-gen/) or in the repository [docs/index.html](docs/index.html). (To build the documentation yourself use [pdoc3](https://pdoc3.github.io/pdoc/) and run `$ pdoc --html tektronix_func_gen`.)
+Tested on Win10 with NI-VISA and PyVISA v1.11 (if using PyVISA <v1.11 use <v0.4
+of this module).
 
-Tested on Win10 with NI-VISA and PyVISA v1.11 (if using PyVISA <v1.11 use <v0.4 of this module).
 
+### Known issues
 
-## Known issues
+- **For TekVISA users:** a `pyvisa.errors.VI_ERROR_IO` is raised unless the
+  Call Monitor application that comes with TekVISA is open and capturing
+  (see issue [#1](https://github.com/asvela/tektronix-func-gen/issues/1)).
+  NI-VISA does not have this issue.
+- The offset of the built-in DC (flat) function cannot be controlled. A
+  workaround is to transfer a flat custom waveform to a memory location,
+  see [Flat function offset control](#flat-function-offset-control) in this readme.
 
-- **For TekVISA users:** a `pyvisa.errors.VI_ERROR_IO` is raised unless the Call Monitor application that comes with TekVISA is open and capturing (see issue [#1](https://github.com/asvela/tektronix-func-gen/issues/1)). NI-VISA does not have this issue.
-- The offset of the built-in DC (flat) function cannot be controlled. A workaround is to transfer a flat custom waveform to a memory location, see [Flat function offset control](#flat-function-offset-control) in this readme.
+### Installation
 
-## Installation
-
-Put the module file in the folder wherein the python file you will import it from resides.
+Put the module file in the folder wherein the Python file you will import it
+from resides.
 
 **Dependencies:**
-- The package needs VISA to be installed. It is tested with NI-VISA, *TekVISA might not work*, see known issues
-- The Python packages `numpy` and `pyvisa` (>=v1.11) are required 
+
+  - The package needs VISA to be installed. It is tested with NI-VISA,
+    *TekVISA might not work*, see `Known issues`
+  - The Python packages `numpy` and `pyvisa` (>=v1.11) are required
 
 
-## Usage (through examples)
+### Usage (through examples)
 
 An example of basic control
 
@@ -75,9 +85,10 @@ with tfg.FuncGen('VISA ADDRESS OF YOUR INSTRUMENT') as fgen:
 ```
 
 
-### Syncronisation and frequency lock
+#### Syncronisation and frequency lock
 
-The phase of the two channels can be syncronised with `syncronise_waveforms()`. Frequency lock can also be enabled/disabled with `set_frequency_lock()`:
+The phase of the two channels can be syncronised with `syncronise_waveforms()`.
+Frequency lock can also be enabled/disabled with `set_frequency_lock()`:
 
 ```python
 """Example showing the frequency being set to 10Hz and then the frequency
@@ -89,9 +100,10 @@ with tfg.FuncGen('VISA ADDRESS OF YOUR INSTRUMENT', verbose=False) as fgen:
 ```
 
 
-### Arbitrary waveforms
+#### Arbitrary waveforms
 
-14 bit vertical resolution arbitrary waveforms can be transferred to the 256 available user defined functions on the function generator.
+14 bit vertical resolution arbitrary waveforms can be transferred to the 256
+available user defined functions on the function generator.
 The length of the waveform must be between 2 and 8192 points.
 
 ```python
@@ -115,9 +127,12 @@ with tfg.FuncGen('VISA ADDRESS OF YOUR INSTRUMENT') as fgen:
       fgen.print_settings()
 ```
 
-#### Flat function offset control
+##### Flat function offset control
 
-The offset of the built-in DC function cannot be controlled (the offset command simply does not work, an issue from Tektronix). A workaround is to transfer a flat custom waveform (two or more points of half the vertical range (`arbitrary_waveform_resolution`)) to a memory location:
+The offset of the built-in DC function cannot be controlled (the offset command
+simply does not work, an issue from Tektronix). A workaround is to transfer a
+flat custom waveform (two or more points of half the vertical range
+(`arbitrary_waveform_resolution`)) to a memory location:
 
 ```python
 with tfg.FuncGen('VISA ADDRESS OF YOUR INSTRUMENT') as fgen:
@@ -130,9 +145,11 @@ with tfg.FuncGen('VISA ADDRESS OF YOUR INSTRUMENT') as fgen:
 Note the `normalise=False` argument.
 
 
-### Set voltage and frequency limits
+#### Set voltage and frequency limits
 
-Limits for amplitude, voltage and frequency for each channel are kept in a dictionary `FuncGenChannel.channel_limits`  (these are the standard limits for AFG1022)
+Limits for amplitude, voltage and frequency for each channel are kept in a
+dictionary `FuncGenChannel.channel_limits` (these are the standard limits
+  for AFG1022)
 
 ```python
 channel_limits = {
@@ -143,7 +160,8 @@ channel_limits = {
                       "highZ": {"min": 0.002, "max": 20}}, "Vpp")}
 ```
 
-They chan be changed by `FuncGenChannel.set_limit()`, or by using the `FuncGenChannel.set_stricter_limits()` for a series of prompts.
+They chan be changed by `FuncGenChannel.set_limit()`, or by using the
+`FuncGenChannel.set_stricter_limits()` for a series of prompts.
 
 ```python
 import tektronix_func_gen as tfg
@@ -163,6 +181,9 @@ with tfg.FuncGen('VISA ADDRESS OF YOUR INSTRUMENT') as fgen:
 ```
 
 
-### Impedance
+#### Impedance
 
-Unfortunately the impedance (50Ω or high Z) cannot be controlled or read remotely. Which setting is in use affects the limits of the output voltage. Use the optional impedance keyword in the initialisation of the func_gen object to make the object aware what limits applies: `FuncGen('VISA ADDRESS OF YOUR INSTRUMENT', impedance=("highZ", "50ohm"))`.
+Unfortunately the impedance (50Ω or high Z) cannot be controlled or read remotely.
+Which setting is in use affects the limits of the output voltage. Use the optional
+impedance keyword in the initialisation of the `FuncGen` object to make the object
+aware what limits applies: `FuncGen('VISA ADDRESS OF YOUR INSTRUMENT', impedance=("highZ", "50ohm"))`.

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,15 +3,17 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
-<meta name="generator" content="pdoc 0.7.5" />
+<meta name="generator" content="pdoc 0.9.2" />
 <title>tektronix_func_gen API documentation</title>
-<meta name="description" content="Tektronix arbitrary function generator control through PyVISA …" />
-<link href='https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.0/normalize.min.css' rel='stylesheet'>
-<link href='https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/8.0.0/sanitize.min.css' rel='stylesheet'>
-<link href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/github.min.css" rel="stylesheet">
-<style>.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{font-weight:bold}#index h4 + ul{margin-bottom:.6em}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
-<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<meta name="description" content="Tektronix arbitrary function generator control …" />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
 <style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
 </head>
 <body>
 <main>
@@ -20,49 +22,161 @@
 <h1 class="title">Module <code>tektronix_func_gen</code></h1>
 </header>
 <section id="section-intro">
-<h2 id="tektronix-arbitrary-function-generator-control-through-pyvisa">Tektronix arbitrary function generator control through PyVISA</h2>
-<p>Andreas Svela 2020</p>
-<p>To build the documentation use <a href="https://pdoc3.github.io/pdoc/">pdoc3</a> and
-run <code>$ pdoc --html tektronix_func_gen</code></p>
-<p>Tested on Win10 with NI-VISA.</p>
-<h2 id="todo">Todo</h2>
+<h2 id="tektronix-arbitrary-function-generator-control">Tektronix arbitrary function generator control</h2>
+<p>API documentation available <a href="https://asvela.github.io/tektronix-func-gen/">here</a>,
+or in the repository <a href="docs/index.html">docs/index.html</a>. (To build the documentation
+yourself use <a href="https://pdoc3.github.io/pdoc/">pdoc3</a> and run
+<code>$ python3 pdoc --html -o ./docs/ tektronix_func_gen</code>.)</p>
+<p>Tested on Win10 with NI-VISA and PyVISA v1.11 (if using PyVISA &lt;v1.11 use &lt;v0.4
+of this module).</p>
+<h3 id="known-issues">Known issues</h3>
 <ul>
-<li>add AM/FM capabilites</li>
+<li><strong>For TekVISA users:</strong> a <code>pyvisa.errors.VI_ERROR_IO</code> is raised unless the
+Call Monitor application that comes with TekVISA is open and capturing
+(see issue <a href="https://github.com/asvela/tektronix-func-gen/issues/1">#1</a>).
+NI-VISA does not have this issue.</li>
+<li>The offset of the built-in DC (flat) function cannot be controlled. A
+workaround is to transfer a flat custom waveform to a memory location,
+see <a href="#flat-function-offset-control">Flat function offset control</a> in this readme.</li>
 </ul>
-<h2 id="notes">Notes</h2>
+<h3 id="installation">Installation</h3>
+<p>Put the module file in the folder wherein the Python file you will import it
+from resides.</p>
+<p><strong>Dependencies:</strong></p>
 <ul>
-<li><strong>For TekVISA users:</strong> a <code>pyvisa.errors.VI_ERROR_IO</code> is raised unless
-the Call Monitor application that comes with TekVISA is open and capturing
-(see issue <a href="https://github.com/asvela/tektronix-func-gen/issues/1">#1</a>)</li>
-<li>The offset of the built-in DC function cannot be controlled. A workaround
-is to transfer a flat custom waveform to a memory location, see README.md
--&gt; Arbitrary waveforms -&gt; Flat function offset control</li>
+<li>The package needs VISA to be installed. It is tested with NI-VISA,
+<em>TekVISA might not work</em>, see <code>Known issues</code></li>
+<li>The Python packages <code>numpy</code> and <code>pyvisa</code> (&gt;=v1.11) are required</li>
 </ul>
+<h3 id="usage-through-examples">Usage (through examples)</h3>
+<p>An example of basic control</p>
+<pre><code class="python">import tektronix_func_gen as tfg
+
+with tfg.FuncGen('VISA ADDRESS OF YOUR INSTRUMENT') as fgen:
+      fgen.ch1.set_function(&quot;SIN&quot;)
+      fgen.ch1.set_frequency(25, unit=&quot;Hz&quot;)
+      fgen.ch1.set_offset(50, unit=&quot;mV&quot;)
+      fgen.ch1.set_amplitude(0.002)
+      fgen.ch1.set_output(&quot;ON&quot;)
+      fgen.ch2.set_output(&quot;OFF&quot;)
+      # alternatively fgen.ch1.print_settings() to show from one channel only
+      fgen.print_settings()
+</code></pre>
+<p>yields something like (depending on the settings already in use)</p>
+<pre><code>Connected to TEKTRONIX model AFG1022, serial XXXXX
+
+Current settings for TEKTRONIX AFG1022 XXXXX
+
+  Setting Ch1   Ch2   Unit
+==========================
+   output ON    OFF    
+ function SIN   RAMP  
+amplitude 0.002 1     Vpp
+   offset 0.05  -0.45 V
+frequency 25.0  10.0  Hz
+</code></pre>
+<p>Settings can also be stored and restored:</p>
+<pre><code class="python">&quot;&quot;&quot;Example showing how to connect, get the current settings of
+the instrument, store them, change a setting and then restore the
+initial settings&quot;&quot;&quot;
+import tektronix_func_gen as tfg
+with tfg.FuncGen('VISA ADDRESS OF YOUR INSTRUMENT') as fgen:
+    fgen.print_settings()
+    print(&quot;Saving these settings..&quot;)
+    settings = fgen.get_settings()
+    print(&quot;Change to 1Vpp amplitude for channel 1..&quot;)
+    fgen.ch1.set_amplitude(1)
+    fgen.print_settings()
+    print(&quot;Reset back to initial settings..&quot;)
+    fgen.set_settings(settings)
+    fgen.print_settings()
+</code></pre>
+<h4 id="syncronisation-and-frequency-lock">Syncronisation and frequency lock</h4>
+<p>The phase of the two channels can be syncronised with <code>syncronise_waveforms()</code>.
+Frequency lock can also be enabled/disabled with <code>set_frequency_lock()</code>:</p>
+<pre><code class="python">&quot;&quot;&quot;Example showing the frequency being set to 10Hz and then the frequency
+lock enabled, using the frequency at ch1 as the common frequency&quot;&quot;&quot;
+import tektronix_func_gen as tfg
+with tfg.FuncGen('VISA ADDRESS OF YOUR INSTRUMENT', verbose=False) as fgen:
+    fgen.ch1.set_frequency(10)
+    fgen.set_frequency_lock(&quot;ON&quot;, use_channel=1)
+</code></pre>
+<h4 id="arbitrary-waveforms">Arbitrary waveforms</h4>
+<p>14 bit vertical resolution arbitrary waveforms can be transferred to the 256
+available user defined functions on the function generator.
+The length of the waveform must be between 2 and 8192 points.</p>
+<pre><code class="python">import numpy as np
+import tektronix_func_gen as tfg
+with tfg.FuncGen('VISA ADDRESS OF YOUR INSTRUMENT') as fgen:
+      # create waveform
+      x = np.linspace(0, 4*np.pi, 8000)
+      waveform = np.sin(x)+x/5
+      # transfer the waveform (normalises to the vertical waveform range)
+      fgen.set_custom_waveform(waveform, memory_num=5, verify=True)
+      # done, but let's have a look at the waveform catalogue ..
+      print(&quot;New waveform catalogue:&quot;)
+      for i, wav in enumerate(fgen.get_waveform_catalogue()): print(&quot;  {}: {}&quot;.format(i, wav))
+      # .. and set the waveform to channel 1
+      print(&quot;Set new wavefrom to channel 1..&quot;, end=&quot; &quot;)
+      fgen.ch1.set_output(&quot;OFF&quot;)
+      fgen.ch1.set_function(&quot;USER5&quot;)
+      print(&quot;ok&quot;)
+      # print current settings
+      fgen.print_settings()
+</code></pre>
+<h5 id="flat-function-offset-control">Flat function offset control</h5>
+<p>The offset of the built-in DC function cannot be controlled (the offset command
+simply does not work, an issue from Tektronix). A workaround is to transfer a
+flat custom waveform (two or more points of half the vertical range
+(<code>arbitrary_waveform_resolution</code>)) to a memory location:</p>
+<pre><code class="python">with tfg.FuncGen('VISA ADDRESS OF YOUR INSTRUMENT') as fgen:
+    flat_wfm = int(fgen.arbitrary_waveform_resolution/2)*np.ones(2).astype(np.int32)
+    fgen.set_custom_waveform(flat_wfm, memory_num=255, normalise=False)
+    fgen.ch1.set_function(&quot;USER255&quot;)
+    fgen.ch1.set_offset(2)
+</code></pre>
+<p>Note the <code>normalise=False</code> argument.</p>
+<h4 id="set-voltage-and-frequency-limits">Set voltage and frequency limits</h4>
+<p>Limits for amplitude, voltage and frequency for each channel are kept in a
+dictionary <code><a title="tektronix_func_gen.FuncGenChannel.channel_limits" href="#tektronix_func_gen.FuncGenChannel.channel_limits">FuncGenChannel.channel_limits</a></code> (these are the standard limits
+for AFG1022)</p>
+<pre><code class="python">channel_limits = {
+  &quot;frequency lims&quot;: ({&quot;min&quot;: 1e-6, &quot;max&quot;: 25e6}, &quot;Hz&quot;),
+  &quot;voltage lims&quot;:   ({&quot;50ohm&quot;: {&quot;min&quot;: -5, &quot;max&quot;: 5},
+                      &quot;highZ&quot;: {&quot;min&quot;: -10, &quot;max&quot;: 10}}, &quot;V&quot;),
+  &quot;amplitude lims&quot;: ({&quot;50ohm&quot;: {&quot;min&quot;: 0.001, &quot;max&quot;: 10},
+                      &quot;highZ&quot;: {&quot;min&quot;: 0.002, &quot;max&quot;: 20}}, &quot;Vpp&quot;)}
+</code></pre>
+<p>They chan be changed by <code><a title="tektronix_func_gen.FuncGenChannel.set_limit" href="#tektronix_func_gen.FuncGenChannel.set_limit">FuncGenChannel.set_limit()</a></code>, or by using the
+<code><a title="tektronix_func_gen.FuncGenChannel.set_stricter_limits" href="#tektronix_func_gen.FuncGenChannel.set_stricter_limits">FuncGenChannel.set_stricter_limits()</a></code> for a series of prompts.</p>
+<pre><code class="python">import tektronix_func_gen as tfg
+&quot;&quot;&quot;Example showing how limits can be read and changed&quot;&quot;&quot;
+with tfg.FuncGen('VISA ADDRESS OF YOUR INSTRUMENT') as fgen:
+    lims = fgen.ch1.get_frequency_lims()
+    print(&quot;Channel 1 frequency limits: {}&quot;.format(lims))
+    print(&quot;Change the lower limit to 2Hz..&quot;)
+    fgen.ch1.set_limit(&quot;frequency lims&quot;, &quot;min&quot;, 2)
+    lims = fgen.ch1.get_frequency_lims()
+    print(&quot;Channel 1 frequency limits: {}&quot;.format(lims))
+    print(&quot;Try to set ch1 frequency to 1Hz..&quot;)
+    try:
+        fgen.ch1.set_frequency(1)
+    except NotSetError as err:
+        print(err)
+</code></pre>
+<h4 id="impedance">Impedance</h4>
+<p>Unfortunately the impedance (50Ω or high Z) cannot be controlled or read remotely.
+Which setting is in use affects the limits of the output voltage. Use the optional
+impedance keyword in the initialisation of the <code><a title="tektronix_func_gen.FuncGen" href="#tektronix_func_gen.FuncGen">FuncGen</a></code> object to make the object
+aware what limits applies: <code>FuncGen('VISA ADDRESS OF YOUR INSTRUMENT', impedance=("highZ", "50ohm"))</code>.</p>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
 <pre><code class="python"># -*- coding: utf-8 -*-
 &#34;&#34;&#34;
-## Tektronix arbitrary function generator control through PyVISA
+.. include:: ./README.md
 
-Andreas Svela 2020
-
-To build the documentation use [pdoc3](https://pdoc3.github.io/pdoc/) and
-run `$ pdoc --html tektronix_func_gen`
-
-Tested on Win10 with NI-VISA.
-
-Todo:
-  * add AM/FM capabilites
-
-Notes:
-  * **For TekVISA users:** a `pyvisa.errors.VI_ERROR_IO` is raised unless
-    the Call Monitor application that comes with TekVISA is open and capturing
-    (see issue [#1](https://github.com/asvela/tektronix-func-gen/issues/1))
-  * The offset of the built-in DC function cannot be controlled. A workaround
-    is to transfer a flat custom waveform to a memory location, see README.md
-    -&gt; Arbitrary waveforms -&gt; Flat function offset control
 &#34;&#34;&#34;
 
 import copy
@@ -70,15 +184,56 @@ import pyvisa
 import numpy as np
 
 
+_VISA_ADDRESS = &#34;USB0::0x0699::0x0353::1731975::INSTR&#34;
+
+
+def _SI_prefix_to_factor(unit):
+    &#34;&#34;&#34;Convert an SI prefix to a numerical factor
+
+    Parameters
+    ----------
+    unit : str
+        The unit whose first character is checked against the list of
+        prefactors {&#34;M&#34;: 1e6, &#34;k&#34;: 1e3, &#34;m&#34;: 1e-3}
+
+    Returns
+    -------
+    factor : float or `None`
+        The appropriate factor or 1 if not found in the list, or `None`
+        if the unit string is empty
+    &#34;&#34;&#34;
+    # SI prefix to numerical value
+    SI_conversion = {&#34;M&#34;: 1e6, &#34;k&#34;: 1e3, &#34;m&#34;: 1e-3}
+    try:  # using the unit&#39;s first character as key in the dictionary
+        factor = SI_conversion[unit[0]]
+    except KeyError:  # if the entry does not exist
+        factor = 1
+    except IndexError:  # if the unit string is empty
+        factor = None
+        return factor
+
+
+## ~~~~~~~~~~~~~~~~~~~~~~~~~~~ ERROR CLASSES ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ##
+
+
+class NotSetError(Exception):
+    &#34;&#34;&#34;Error for when a value cannot be written to the instrument&#34;&#34;&#34;
+
+
+class NotCompatibleError(Exception):
+    &#34;&#34;&#34;Error for when the instrument is not compatible with this module&#34;&#34;&#34;
+
+
 ## ~~~~~~~~~~~~~~~~~~~~~ FUNCTION GENERATOR CLASS ~~~~~~~~~~~~~~~~~~~~~~~~~~ ##
 
-class FuncGen():
+
+class FuncGen:
     &#34;&#34;&#34;Class for interacting with Tektronix function generator
 
     Parameters
     ----------
-    address : str
-        VISA address of insrument
+    visa_address : str
+        VISA address of the insrument
     impedance : tuple of {&#34;highZ&#34;, &#34;50ohm&#34;}, default (&#34;highZ&#34;,)*2
         Determines voltage limits associated with high impedance (whether the
         instrument is using 50ohm or high Z cannot be controlled through VISA).
@@ -98,36 +253,17 @@ class FuncGen():
 
     Attributes
     ----------
-    address : str
+    _visa_address : str
         The VISA address of the instrument
-    id : str
+    _id : str
         Comma separated string with maker, model, serial and firmware of
         the instrument
-    inst : `pyvisa.resources.Resource`
+    _inst : `pyvisa.resources.Resource`
         The PyVISA resource
-    channels : tuple of FuncGenChannel
-        Objects to control the channels
-    ch1 : FuncGenChannel
-        Short hand for `channels[0]` Object to control channel 1
-    ch2 : FuncGenChannel
-        Short hand for `channels[1]` Object to control channel 2
-    instrument_limits : dict
-        Contains the following keys with subdictionaries
-        `frequency lims`
-            Containing the frequency limits for the instrument where the keys
-            &#34;min&#34; and &#34;max&#34; have values corresponding to minimum and maximum
-            frequencies in Hz
-        `voltage lims`
-            Contains the maximum absolute voltage the instrument can output
-            for the keys &#34;50ohm&#34; and &#34;highZ&#34; according to the impedance setting
-        `amplitude lims`
-            Contains the smallest and largest possible amplitudes where the
-            keys &#34;50ohm&#34; and &#34;highZ&#34; will have subdictionaries with keys
-            &#34;min&#34; and &#34;max&#34;
-    arbitrary_waveform_length : list
+    _arbitrary_waveform_length : list
         The permitted minimum and maximum length of an arbitrary waveform,
         e.g. [2, 8192]
-    arbitrary_waveform_resolution : int
+    _arbitrary_waveform_resolution : int
         The vertical resolution of the arbitrary waveform, for instance 14 bit
         =&gt; 2**14-1 = 16383
 
@@ -141,38 +277,70 @@ class FuncGen():
         use AFG1022 limits)
     &#34;&#34;&#34;
 
-    def __init__(self, address, impedance=(&#34;highZ&#34;,)*2, timeout=5000,
-                 verify_param_set=False, override_compatibility=False,
-                 verbose=True):
-        self.override_compatibility = override_compatibility
-        self.address = address
-        self.timeout = timeout
+    instrument_limits = {}
+    &#34;&#34;&#34;dict: Contains the following keys with subdictionaries
+
+        - `frequency lims`
+          Containing the frequency limits for the instrument where the keys
+          &#34;min&#34; and &#34;max&#34; have values corresponding to minimum and maximum
+          frequencies in Hz
+        - `voltage lims`
+          Contains the maximum absolute voltage the instrument can output
+          for the keys &#34;50ohm&#34; and &#34;highZ&#34; according to the impedance setting
+        - `amplitude lims`
+          Contains the smallest and largest possible amplitudes where the
+          keys &#34;50ohm&#34; and &#34;highZ&#34; will have subdictionaries with keys
+          &#34;min&#34; and &#34;max&#34;
+    &#34;&#34;&#34;
+
+    def __init__(
+        self,
+        visa_address,
+        impedance=(&#34;highZ&#34;,) * 2,
+        timeout=5000,
+        verify_param_set=False,
+        override_compatibility=False,
+        verbose=True,
+    ):
+        self._override_compatibility = override_compatibility
+        self._visa_address = visa_address
+        self._timeout = timeout
         self.verify_param_set = verify_param_set
+        &#34;&#34;&#34;bool:  Verify that a value is successfully set after executing a set function&#34;&#34;&#34;
         self.verbose = verbose
+        &#34;&#34;&#34;bool: Choose whether to print information such as model upon connecting etc&#34;&#34;&#34;
         try:
             rm = pyvisa.ResourceManager()
-            self.inst = rm.open_resource(address)
+            self._inst = rm.open_resource(visa_address)
         except pyvisa.Error:
-            print(&#34;\nVisaError: Could not connect to \&#39;{}\&#39;&#34;.format(address))
+            print(f&#34;\nVisaError: Could not connect to &#39;{visa_address}&#39;&#34;)
             raise
-        self.inst.timeout = self.timeout
+        self._inst.timeout = self._timeout
         # Clear all the event registers and queues used in the instrument
         # status and event reporting system
         self.write(&#34;*CLS&#34;)
         # Get information about the connected device
-        self.id = self.query(&#34;*IDN?&#34;)
+        self._id = self.query(&#34;*IDN?&#34;)
         # Second query might be needed due to unknown reason
         # (suspecting *CLS does something weird)
-        if self.id == &#39;&#39;:
-            self.id = self.query(&#34;*IDN?&#34;)
-        self.maker, self.model, self.serial = self.id.split(&#34;,&#34;)[:3]
+        if self._id == &#34;&#34;:
+            self._id = self.query(&#34;*IDN?&#34;)
+        self._maker, self._model, self._serial = self._id.split(&#34;,&#34;)[:3]
         if self.verbose:
-            print(&#34;Connected to {} model {}, serial&#34;
-                  &#34; {}&#34;.format(self.maker, self.model, self.serial))
-        self.initialise_model_properties()
-        self.channels = (self.spawn_channel(1, impedance[0]),
-                         self.spawn_channel(2, impedance[1]))
-        self.ch1, self.ch2 = self.channels
+            print(
+                &#34;Connected to {} model {}, serial&#34;
+                &#34; {}&#34;.format(self._maker, self._model, self._serial)
+            )
+        self._initialise_model_properties()
+        self.channels = (
+            self._spawn_channel(1, impedance[0]),
+            self._spawn_channel(2, impedance[1]),
+        )
+        &#34;&#34;&#34;tuple of `FuncGenChannel`: Objects to control the channels&#34;&#34;&#34;
+        self.ch1 = self.channels[0]
+        &#34;&#34;&#34;`FuncGenChannel`: Short hand for `channels[0]` Object to control channel 1&#34;&#34;&#34;
+        self.ch2 = self.channels[1]
+        &#34;&#34;&#34;`FuncGenChannel`: Short hand for `channels[1]` Object to control channel 2&#34;&#34;&#34;
 
     def __enter__(self, **kwargs):
         # The kwargs will be passed on to __init__
@@ -186,9 +354,9 @@ class FuncGen():
 
     def close(self):
         &#34;&#34;&#34;Close the connection to the instrument&#34;&#34;&#34;
-        self.inst.close()
+        self._inst.close()
 
-    def initialise_model_properties(self):
+    def _initialise_model_properties(self):
         &#34;&#34;&#34;Initialises the limits of what the instrument can handle according
         to the instrument model
 
@@ -198,21 +366,31 @@ class FuncGen():
             If the connected model is not necessarily compatible with this
             package, slimits are not known.
         &#34;&#34;&#34;
-        if self.model == &#39;AFG1022&#39; or self.override_compatibility:
+        if self._model == &#34;AFG1022&#34; or self._override_compatibility:
             self.instrument_limits = {
                 &#34;frequency lims&#34;: ({&#34;min&#34;: 1e-6, &#34;max&#34;: 25e6}, &#34;Hz&#34;),
-                &#34;voltage lims&#34;:   ({&#34;50ohm&#34;: {&#34;min&#34;: -5, &#34;max&#34;: 5},
-                                    &#34;highZ&#34;: {&#34;min&#34;: -10, &#34;max&#34;: 10}}, &#34;V&#34;),
-                &#34;amplitude lims&#34;: ({&#34;50ohm&#34;: {&#34;min&#34;: 0.001, &#34;max&#34;: 10},
-                                    &#34;highZ&#34;: {&#34;min&#34;: 0.002, &#34;max&#34;: 20}}, &#34;Vpp&#34;)}
-            self.arbitrary_waveform_length = [2, 8192]  # min length, max length
-            self.arbitrary_waveform_resolution = 16383  # 14 bit
+                &#34;voltage lims&#34;: (
+                    {&#34;50ohm&#34;: {&#34;min&#34;: -5, &#34;max&#34;: 5}, &#34;highZ&#34;: {&#34;min&#34;: -10, &#34;max&#34;: 10}},
+                    &#34;V&#34;,
+                ),
+                &#34;amplitude lims&#34;: (
+                    {
+                        &#34;50ohm&#34;: {&#34;min&#34;: 0.001, &#34;max&#34;: 10},
+                        &#34;highZ&#34;: {&#34;min&#34;: 0.002, &#34;max&#34;: 20},
+                    },
+                    &#34;Vpp&#34;,
+                ),
+            }
+            self._arbitrary_waveform_length = [2, 8192]  # min length, max length
+            self._arbitrary_waveform_resolution = 16383  # 14 bit
         else:
-            msg = (&#34;Model {} not supported, no limits set!&#34;
-                   &#34;\n\tTo use the limits for AFG1022, call the class with &#34;
-                   &#34;&#39;override_compatibility=True&#39;&#34;
-                   &#34;\n\tNote that this might lead to unexpected behaviour &#34;
-                   &#34;for custom waveforms and &#39;MIN&#39;/&#39;MAX&#39; keywords.&#34;)
+            msg = (
+                &#34;Model {} not supported, no limits set!&#34;
+                &#34;\n\tTo use the limits for AFG1022, call the class with &#34;
+                &#34;&#39;override_compatibility=True&#39;&#34;
+                &#34;\n\tNote that this might lead to unexpected behaviour &#34;
+                &#34;for custom waveforms and &#39;MIN&#39;/&#39;MAX&#39; keywords.&#34;
+            )
             raise NotCompatibleError(msg)
 
     def write(self, command, custom_err_message=None):
@@ -239,8 +417,8 @@ class FuncGen():
             If status returned by PyVISA write command is not
             `pyvisa.constants.StatusCode.success`
         &#34;&#34;&#34;
-        num_bytes = self.inst.write(command)
-        self.check_pyvisa_status(command, custom_err_message=custom_err_message)
+        num_bytes = self._inst.write(command)
+        self._check_pyvisa_status(command, custom_err_message=custom_err_message)
         return num_bytes
 
     def query(self, command, custom_err_message=None):
@@ -267,11 +445,11 @@ class FuncGen():
             If status returned by PyVISA write command is not
             `pyvisa.constants.StatusCode.success`
         &#34;&#34;&#34;
-        response = self.inst.query(command).strip()
-        self.check_pyvisa_status(command, custom_err_message=custom_err_message)
+        response = self._inst.query(command).strip()
+        self._check_pyvisa_status(command, custom_err_message=custom_err_message)
         return response
 
-    def check_pyvisa_status(self, command, custom_err_message=None):
+    def _check_pyvisa_status(self, command, custom_err_message=None):
         &#34;&#34;&#34;Check the last status code of PyVISA
 
         Parameters
@@ -290,16 +468,19 @@ class FuncGen():
             If status returned by PyVISA write command is not
             `pyvisa.constants.StatusCode.success`
         &#34;&#34;&#34;
-        status = self.inst.last_status
+        status = self._inst.last_status
         if not status == pyvisa.constants.StatusCode.success:
             if custom_err_message is not None:
-                msg = (&#34;Could not {}: pyvisa returned StatusCode {} &#34;
-                       &#34;({})&#34;.format(custom_err_message, status, str(status)))
+                msg = (
+                    f&#34;Could not {custom_err_message}: pyvisa returned &#34;
+                    f&#34;StatusCode {status} ({str(status)})&#34;
+                )
                 raise RuntimeError(msg)
-            else:
-                msg = (&#34;Writing/querying command {} failed: pyvisa returned StatusCode&#34;
-                       &#34; {} ({})&#34;.format(command, status, str(status)))
-                raise RuntimeError(msg)
+            msg = (
+                f&#34;Writing/querying command {command} failed: pyvisa returned &#34;
+                f&#34;StatusCode {status} ({str(status)})&#34;
+            )
+            raise RuntimeError(msg)
         return status
 
     def get_error(self):
@@ -312,7 +493,7 @@ class FuncGen():
         &#34;&#34;&#34;
         return self.query(&#34;SYSTEM:ERROR:NEXT?&#34;)
 
-    def spawn_channel(self, channel, impedance):
+    def _spawn_channel(self, channel, impedance):
         &#34;&#34;&#34;Wrapper function to create a `FuncGenChannel` object for
         a channel -- see the class docstring&#34;&#34;&#34;
         return FuncGenChannel(self, channel, impedance)
@@ -335,27 +516,28 @@ class FuncGen():
         # Find the necessary padding for the table columns
         # by evaluating the maximum length of the entries
         key_padding = max([len(key) for key in settings[0].keys()])
-        ch_paddings = [max([len(str(val[0])) for val in ch_settings.values()])
-                       for ch_settings in settings]
-        padding = [key_padding]+ch_paddings
-        print(&#34;\nCurrent settings for {} {} {}\n&#34;.format(self.maker,
-                                                         self.model,
-                                                         self.serial))
+        ch_paddings = [
+            max([len(str(val[0])) for val in ch_settings.values()])
+            for ch_settings in settings
+        ]
+        padding = [key_padding] + ch_paddings
+        print(f&#34;\nCurrent settings for {self._maker} {self._model} {self._serial}\n&#34;)
         row_format = &#34;{:&gt;{padd[0]}s} {:{padd[1]}s} {:{padd[2]}s} {}&#34;
-        table_header = row_format.format(&#34;Setting&#34;, &#34;Ch1&#34;, &#34;Ch2&#34;,
-                                         &#34;Unit&#34;, padd=padding)
+        table_header = row_format.format(&#34;Setting&#34;, &#34;Ch1&#34;, &#34;Ch2&#34;, &#34;Unit&#34;, padd=padding)
         print(table_header)
-        print(&#34;=&#34;*len(table_header))
-        for (ch1key, (ch1val, unit)), (_, (ch2val, _)) in zip(settings[0].items(),
-                                                              settings[1].items()):
-            print(row_format.format(ch1key, str(ch1val), str(ch2val),
-                                    unit, padd=padding))
+        print(&#34;=&#34; * len(table_header))
+        for (ch1key, (ch1val, unit)), (_, (ch2val, _)) in zip(
+            settings[0].items(), settings[1].items()
+        ):
+            print(
+                row_format.format(ch1key, str(ch1val), str(ch2val), unit, padd=padding)
+            )
 
     def set_settings(self, settings):
         &#34;&#34;&#34;Set the settings of both channels with settings dictionaries
 
         (Each channel is turned off before applying the changes to avoid
-        potenitally harmful combinations)
+        potentially harmful combinations)
 
         Parameteres
         -----------
@@ -402,23 +584,26 @@ class FuncGen():
         &#34;&#34;&#34;
         if self.verbose:
             if state.lower() == &#34;off&#34; and not self.get_frequency_lock():
-                print(&#34;(!) {}: Tried to disable frequency lock, but &#34;
-                      &#34;frequency lock was not enabled&#34;.format(self.model))
+                print(
+                    f&#34;(!) {self._model}: Tried to disable frequency lock, but &#34;
+                    f&#34;frequency lock was not enabled&#34;
+                )
                 return
             if state.lower() == &#34;on&#34; and self.get_frequency_lock():
-                print(&#34;(!) {}: Tried to enable frequency lock, but &#34;
-                      &#34;frequency lock was already enabled&#34;.format(self.model))
+                print(
+                    f&#34;(!) {self._model}: Tried to enable frequency lock, but &#34;
+                    f&#34;frequency lock was already enabled&#34;
+                )
                 return
         # (Sufficient to disable for only one of the channels)
-        cmd = &#34;SOURCE{}:FREQuency:CONCurrent {}&#34;.format(use_channel, state)
-        msg = &#34;turn frequency lock {}&#34;.format(state)
+        cmd = f&#34;SOURCE{use_channel}:FREQuency:CONCurrent {state}&#34;
+        msg = f&#34;turn frequency lock {state}&#34;
         self.write(cmd, custom_err_message=msg)
 
     def software_trig(self):
         &#34;&#34;&#34;NOT TESTED: sends a trigger signal to the device
         (for bursts or modulations)&#34;&#34;&#34;
         self.write(&#34;*TRG&#34;, custom_err_message=&#34;send trigger signal&#34;)
-
 
     ## ~~~~~~~~~~~~~~~~~~~~~ CUSTOM WAVEFORM FUNCTIONS ~~~~~~~~~~~~~~~~~~~~~ ##
 
@@ -431,7 +616,7 @@ class FuncGen():
             Strings with the names of the user functions that are not empty
         &#34;&#34;&#34;
         catalogue = self.query(&#34;DATA:CATalog?&#34;).split(&#34;,&#34;)
-        catalogue = [wf[1:-1] for wf in catalogue] # strip off extra quotes
+        catalogue = [wf[1:-1] for wf in catalogue]  # strip off extra quotes
         return catalogue
 
     def get_custom_waveform(self, memory_num):
@@ -450,27 +635,31 @@ class FuncGen():
         &#34;&#34;&#34;
         # Find the wavefroms in use
         waveforms_in_use = self.get_waveform_catalogue()
-        if &#34;USER{}&#34;.format(memory_num) in waveforms_in_use:
+        if f&#34;USER{memory_num}&#34; in waveforms_in_use:
             # Copy the waveform to edit memory
-            self.write(&#34;DATA:COPY EMEMory,USER{}&#34;.format(memory_num))
+            self.write(f&#34;DATA:COPY EMEMory,USER{memory_num}&#34;)
             # Get the length of the waveform
             waveform_length = int(self.query(&#34;DATA:POINts? EMEMory&#34;))
             # Get the waveform (returns binary values)
-            waveform = self.inst.query_binary_values(&#34;DATA:DATA? EMEMory&#34;,
-                                                     datatype=&#39;H&#39;,
-                                                     is_big_endian=True,
-                                                     container=np.ndarray)
-            msg = (&#34;Waveform length from native length command (DATA:POINts?) &#34;
-                   &#34;and the processed binary values do not match, {} and {} &#34;
-                   &#34;respectively&#34;.format(waveform_length, len(waveform)))
+            waveform = self._inst.query_binary_values(
+                &#34;DATA:DATA? EMEMory&#34;,
+                datatype=&#34;H&#34;,
+                is_big_endian=True,
+                container=np.ndarray,
+            )
+            msg = (
+                f&#34;Waveform length from native length command (DATA:POINts?) &#34;
+                f&#34;and the processed binary values do not match, &#34;
+                f&#34;{waveform_length} and {len(waveform)} respectively&#34;
+            )
             assert len(waveform) == waveform_length, msg
             return waveform
-        else:
-            print(&#34;Waveform USER{} is not in use&#34;.format(memory_num))
-            return np.array([])
+        print(f&#34;Waveform USER{memory_num} is not in use&#34;)
+        return np.array([])
 
-    def set_custom_waveform(self, waveform, normalise=True, memory_num=0,
-                            verify=True, print_progress=True):
+    def set_custom_waveform(
+        self, waveform, normalise=True, memory_num=0, verify=True, print_progress=True
+    ):
         &#34;&#34;&#34;Transfer waveform data to edit memory and then user memory.
         NOTE: Will overwrite without warnings
 
@@ -504,55 +693,59 @@ class FuncGen():
         # Check if waveform data is suitable
         if print_progress:
             print(&#34;Check if waveform data is suitable..&#34;, end=&#34; &#34;)
-        self.check_arb_waveform_length(waveform)
+        self._check_arb_waveform_length(waveform)
         try:
-            self.check_arb_waveform_type_and_range(waveform)
-        except ValueError as e:
+            self._check_arb_waveform_type_and_range(waveform)
+        except ValueError as err:
             if print_progress:
-                print(&#34;\n  &#34;+str(e))
+                print(f&#34;\n  {err}&#34;)
                 print(&#34;Trying again normalising the waveform..&#34;, end=&#34; &#34;)
-            waveform = self.normalise_to_waveform(waveform)
+            waveform = self._normalise_to_waveform(waveform)
         if print_progress:
             print(&#34;ok&#34;)
             print(&#34;Transfer waveform to function generator..&#34;, end=&#34; &#34;)
         # Transfer waveform
-        self.inst.write_binary_values(&#34;DATA:DATA EMEMory,&#34;, waveform,
-                                      datatype=&#39;H&#39;, is_big_endian=True)
-        # The first query after the write_binary_values returns &#39;&#39;,
-        # so here is a mock query
-        self.query(&#34;&#34;)
+        self._inst.write_binary_values(
+            &#34;DATA:DATA EMEMory,&#34;, waveform, datatype=&#34;H&#34;, is_big_endian=True
+        )
+        # Check for errors and check lengths are matching
         transfer_error = self.get_error()
         emem_wf_length = self.query(&#34;DATA:POINts? EMEMory&#34;)
-        if emem_wf_length == &#39;&#39; or not int(emem_wf_length) == len(waveform):
-            msg = (&#34;Waveform in temporary EMEMory has a length of {}, not of &#34;
-                   &#34;the same length as the waveform ({}).\nError from the &#34;
-                   &#34;instrument: {}&#34;.format(emem_wf_length, len(waveform),
-                                           transfer_error))
+        if emem_wf_length == &#34;&#34; or not int(emem_wf_length) == len(waveform):
+            msg = (
+                f&#34;Waveform in temporary EMEMory has a length of {emem_wf_length}&#34;
+                f&#34;, not of the same length as the waveform ({len(waveform)}).&#34;
+                f&#34;\nError from the instrument: {transfer_error}&#34;
+            )
             raise RuntimeError(msg)
         if print_progress:
             print(&#34;ok&#34;)
-            print(&#34;Copy waveform to USER{}..&#34;.format(memory_num), end=&#34; &#34;)
-        self.write(&#34;DATA:COPY USER{},EMEMory&#34;.format(memory_num))
+            print(f&#34;Copy waveform to USER{memory_num}..&#34;, end=&#34; &#34;)
+        self.write(f&#34;DATA:COPY USER{memory_num},EMEMory&#34;)
         if print_progress:
             print(&#34;ok&#34;)
         if verify:
             if print_progress:
-                print(&#34;Verify waveform USER{}..&#34;.format(memory_num))
-            if &#34;USER{}&#34;.format(memory_num) in self.get_waveform_catalogue():
-                self.verify_waveform(waveform, memory_num, normalise=normalise,
-                                     print_result=print_progress)
+                print(f&#34;Verify waveform USER{memory_num}..&#34;)
+            if f&#34;USER{memory_num}&#34; in self.get_waveform_catalogue():
+                self._verify_waveform(
+                    waveform,
+                    memory_num,
+                    normalise=normalise,
+                    print_result=print_progress,
+                )
             else:
-                print(&#34;(!) USER{} is empty&#34;.format(memory_num))
+                print(f&#34;(!) USER{memory_num} is empty&#34;)
         return waveform
 
-    def normalise_to_waveform(self, shape):
+    def _normalise_to_waveform(self, shape):
         &#34;&#34;&#34;Normalise a shape of any discretisation and range to a waveform that
         can be transmitted to the function generator
 
         .. note::
             If you are transferring a flat/constant waveform, do not use this
             normaisation function. Transfer a waveform like
-            `int(self.arbitrary_waveform_resolution/2)*np.ones(2).astype(np.int32)`
+            `int(self._arbitrary_waveform_resolution/2)*np.ones(2).astype(np.int32)`
             without normalising for a well behaved flat function.
 
         Parameters
@@ -567,15 +760,14 @@ class FuncGen():
             Waveform as ints spanning the resolution of the function gen
         &#34;&#34;&#34;
         # Check if waveform data is suitable
-        self.check_arb_waveform_length(shape)
+        self._check_arb_waveform_length(shape)
         # Normalise
         waveform = shape - np.min(shape)
         normalisation_factor = np.max(waveform)
-        waveform = waveform/normalisation_factor*self.arbitrary_waveform_resolution
+        waveform = waveform / normalisation_factor * self._arbitrary_waveform_resolution
         return waveform.astype(np.uint16)
 
-    def verify_waveform(self, waveform, memory_num, normalise=True,
-                        print_result=True):
+    def _verify_waveform(self, waveform, memory_num, normalise=True, print_result=True):
         &#34;&#34;&#34;Compare a waveform in user memory to argument waveform
 
         Parameters
@@ -597,17 +789,19 @@ class FuncGen():
             List of the indices where the waveforms are not equal or `None` if
             the waveforms were of different lengths
         &#34;&#34;&#34;
-        if normalise: # make sure test waveform is normalised
-            waveform = self.normalise_to_waveform(waveform)
+        if normalise:  # make sure test waveform is normalised
+            waveform = self._normalise_to_waveform(waveform)
         # Get the waveform on the instrument
         instrument_waveform = self.get_custom_waveform(memory_num)
         # Compare lengths
         len_inst_wav, len_wav = len(instrument_waveform), len(waveform)
         if not len_inst_wav == len_wav:
             if print_result:
-                print(&#34;The waveform in USER{} and the compared waveform are &#34;
-                      &#34;not of same length (instrument {} vs {})&#34;
-                      &#34;&#34;.format(memory_num, len_inst_wav, len_wav))
+                print(
+                    f&#34;The waveform in USER{memory_num} and the compared &#34;
+                    f&#34;waveform are not of same length (instrument &#34;
+                    f&#34;{len_inst_wav} vs {len_wav})&#34;
+                )
             return False, instrument_waveform, None
         # Compare each element
         not_equal = []
@@ -615,17 +809,21 @@ class FuncGen():
             if not instrument_waveform[i] == waveform[i]:
                 not_equal.append(i)
         # Return depending of whether list is empty or not
-        if not not_equal: # if list is empty
+        if not not_equal:  # if list is empty
             if print_result:
-                print(&#34;The waveform in USER{} and the compared waveform &#34;
-                      &#34;are equal&#34;.format(memory_num))
+                print(
+                    f&#34;The waveform in USER{memory_num} and the compared &#34;
+                    f&#34;waveform are equal&#34;
+                )
             return True, instrument_waveform, not_equal
         if print_result:
-            print(&#34;The waveform in USER{} and the compared waveform are &#34;
-                  &#34;NOT equal&#34;.format(memory_num))
+            print(
+                f&#34;The waveform in USER{memory_num} and the compared &#34;
+                f&#34;waveform are NOT equal&#34;
+            )
         return False, instrument_waveform, not_equal
 
-    def check_arb_waveform_length(self, waveform):
+    def _check_arb_waveform_length(self, waveform):
         &#34;&#34;&#34;Checks if waveform is within the acceptable length
 
         Parameters
@@ -638,14 +836,17 @@ class FuncGen():
         ValueError
             If the waveform is not within the permitted length
         &#34;&#34;&#34;
-        if ((len(waveform) &lt; self.arbitrary_waveform_length[0]) or
-            (len(waveform) &gt; self.arbitrary_waveform_length[1])):
-            msg = (&#34;The waveform is of length {}, which is not within the &#34;
-                   &#34;acceptable length {} &lt; len &lt; {}&#34;
-                   &#34;&#34;.format(len(waveform), *self.arbitrary_waveform_length))
+        if (len(waveform) &lt; self._arbitrary_waveform_length[0]) or (
+            len(waveform) &gt; self._arbitrary_waveform_length[1]
+        ):
+            msg = (
+                &#34;The waveform is of length {}, which is not within the &#34;
+                &#34;acceptable length {} &lt; len &lt; {}&#34;
+                &#34;&#34;.format(len(waveform), *self._arbitrary_waveform_length)
+            )
             raise ValueError(msg)
 
-    def check_arb_waveform_type_and_range(self, waveform):
+    def _check_arb_waveform_type_and_range(self, waveform):
         &#34;&#34;&#34;Checks if waveform is of int/np.int32 type and within the resolution
         of the function generator
 
@@ -662,16 +863,20 @@ class FuncGen():
         &#34;&#34;&#34;
         for value in waveform:
             if not isinstance(value, (int, np.uint16, np.int32)):
-                raise ValueError(&#34;The waveform contains values that are not&#34;
-                                 &#34;int, np.uint16 or np.int32&#34;)
-            if (value &lt; 0) or (value &gt; self.arbitrary_waveform_resolution):
-                raise ValueError(&#34;The waveform contains values out of range &#34;
-                                 &#34;({} is not within the resolution &#34;
-                                 &#34;[0, {}])&#34;.format(value,
-                                        self.arbitrary_waveform_resolution))
+                raise ValueError(
+                    &#34;The waveform contains values that are not&#34;
+                    &#34;int, np.uint16 or np.int32&#34;
+                )
+            if (value &lt; 0) or (value &gt; self._arbitrary_waveform_resolution):
+                raise ValueError(
+                    f&#34;The waveform contains values out of range &#34;
+                    f&#34;({value} is not within the resolution &#34;
+                    f&#34;[0, {self._arbitrary_waveform_resolution}])&#34;
+                )
 
 
 ## ~~~~~~~~~~~~~~~~~~~~~~~ CHANNEL CLASS ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ##
+
 
 class FuncGenChannel:
     &#34;&#34;&#34;Class for controlling a channel on a function generator object
@@ -688,35 +893,31 @@ class FuncGenChannel:
 
     Attributes
     ----------
-    fgen : `FuncGen`
+    _fgen : `FuncGen`
         The function generator object for which the channel exists
-    channel : {1, 2}
-        The channel number
-    impedance : {&#34;50ohm&#34;, &#34;highZ&#34;}
-        Determines voltage limits associated with high impedance (whether the
-        instrument is using 50ohm or high Z cannot be controlled through VISA)
-    source : str
-        &#34;SOURce{}:&#34; where {} is the channel number
-    settings_units : list
-        The units for the settings produced by `FuncGenChannel.get_settings`
-    state_str : dict
-        For conversion from states 1 and 2 to &#34;ON&#34; and &#34;OFF&#34;
+    _channel : {1, 2}
+        The number of the channel this object is addressing
+    _source : str
+        &#34;SOURce{i}:&#34; where {i} is the channel number
     &#34;&#34;&#34;
 
-    # Attributes
-    state_str = {&#34;1&#34;: &#34;ON&#34;, &#34;0&#34;: &#34;OFF&#34;,
-                  1 : &#34;ON&#34;,  0 : &#34;OFF&#34;}
+    _state_to_str = {&#34;1&#34;: &#34;ON&#34;, &#34;0&#34;: &#34;OFF&#34;, 1: &#34;ON&#34;, 0: &#34;OFF&#34;}
     &#34;&#34;&#34;Dictionary for converting output states to &#34;ON&#34; and &#34;OFF&#34; &#34;&#34;&#34;
 
     def __init__(self, fgen, channel, impedance):
-        self.fgen = fgen
-        self.channel = channel
-        self.source = &#34;SOURce{}:&#34;.format(channel)
+        self._fgen = fgen
+        self._channel = channel
+        self._source = f&#34;SOURce{channel}:&#34;
         self.impedance = impedance
+        &#34;&#34;&#34;{&#34;50ohm&#34;, &#34;highZ&#34;}: Determines voltage limits associated with high
+        impedance (whether the instrument is using 50ohm or high Z cannot be
+        controlled through VISA)&#34;&#34;&#34;
         # Adopt limits dictionary from instrument
-        self.channel_limits = copy.deepcopy(self.fgen.instrument_limits)
+        self.channel_limits = copy.deepcopy(self._fgen.instrument_limits)
+        &#34;&#34;&#34;Channel limits for the individual channel, same form as
+        `FuncGen.instrument_limits`&#34;&#34;&#34;
 
-    def impedance_dependent_limit(self, limit_type):
+    def _impedance_dependent_limit(self, limit_type):
         &#34;&#34;&#34;Check if the limit type is impedance dependent (voltages) or
         not (frequency)
 
@@ -725,43 +926,43 @@ class FuncGenChannel:
         bool
             `True` if the limit is impedance dependent
         &#34;&#34;&#34;
-        try: # to access the key &#34;min&#34; to check if impedance must be selected
+        try:  # to access the key &#34;min&#34; to check if impedance must be selected
             _ = self.channel_limits[limit_type][0][&#34;min&#34;]
             return False
-        except KeyError: # if the key does not exist
+        except KeyError:  # if the key does not exist
             # The impedance must be selected
             return True
 
     def set_stricter_limits(self):
         &#34;&#34;&#34;Set limits for the voltage and frequency limits of the channel output
         through a series of prompts&#34;&#34;&#34;
-        print(&#34;Set stricter voltage and frequency limits &#34;
-              &#34;for channel {}&#34;.format(self.channel))
+        print(f&#34;Set stricter voltage and frequency limits for channel {self._channel}&#34;)
         print(&#34;Use enter only to leave a limit unchanged.&#34;)
         # Go through the different limits in the instrument_limits dict
-        for limit_type, (inst_limit_dict, unit) in self.fgen.instrument_limits.items():
-            use_impedance = self.impedance_dependent_limit(limit_type)
-            print(&#34;Set {} in {}&#34;.format(limit_type, unit), end=&#34; &#34;)
+        for limit_type, (inst_limit_dict, unit) in self._fgen.instrument_limits.items():
+            use_impedance = self._impedance_dependent_limit(limit_type)
+            print(f&#34;Set {limit_type} in {unit}&#34;, end=&#34; &#34;)
             if use_impedance:
                 inst_limit_dict = inst_limit_dict[self.impedance]
-                print(&#34;[{} impedance limit]&#34;.format(self.impedance))
+                print(f&#34;[{self.impedance} impedance limit]&#34;)
             else:
-                print(&#34;&#34;) # get new line
+                print(&#34;&#34;)  # get new line
             # Go through the min and max for the limit type
             for key, inst_value in inst_limit_dict.items():
                 # prompt for new value
-                new_value = input(&#34;  {} (instrument limit {}{}): &#34;
-                                  &#34;&#34;.format(key, inst_value, unit))
+                new_value = input(f&#34;  {key} (instrument limit {inst_value}{unit}): &#34;)
                 if new_value == &#34;&#34;:
                     # Do not change if empty
                     print(&#34;\tLimit not changed&#34;)
                 else:
-                    try: # to convert to float
+                    try:  # to convert to float
                         new_value = float(new_value)
                     except ValueError:
-                        print(&#34;\tLimit unchanged: Could not convert \&#39;{}\&#39; &#34;
-                              &#34;to float&#34;.format(new_value))
-                        continue # to next item in dict
+                        print(
+                            f&#34;\tLimit unchanged: Could not convert &#39;{new_value}&#39; &#34;
+                            f&#34;to float&#34;
+                        )
+                        continue  # to next item in dict
                     # Set the new limit
                     self.set_limit(limit_type, key, new_value, verbose=True)
 
@@ -787,10 +988,10 @@ class FuncGenChannel:
             `True` if new limit set, `False` otherwise
         &#34;&#34;&#34;
         # Short hand references
-        inst_limit_dict = self.fgen.instrument_limits[limit_type]
+        inst_limit_dict = self._fgen.instrument_limits[limit_type]
         channel_limit_dict = self.channel_limits[limit_type]
         # Find the instrument limit and unit
-        use_impedance = self.impedance_dependent_limit(limit_type)
+        use_impedance = self._impedance_dependent_limit(limit_type)
         if use_impedance:
             inst_value = inst_limit_dict[0][self.impedance][bound]
         else:
@@ -804,7 +1005,7 @@ class FuncGenChannel:
             current_min = channel_limit_dict[0][&#34;min&#34;]
         larger_than_min = new_value &gt; current_min
         acceptable_max = bound == &#34;max&#34; and new_value &lt; inst_value and larger_than_min
-        if acceptable_min or acceptable_max: # within the limits
+        if acceptable_min or acceptable_max:  # within the limits
             # Set the new channel_limit, using the impedance depending on the
             # limit type. Beware that the shorthand cannot be used, as this
             # only changes the shorthand not the dictionary itself
@@ -813,57 +1014,61 @@ class FuncGenChannel:
             else:
                 self.channel_limits[limit_type][0][bound] = new_value
             if verbose:
-                print(&#34;\tNew limit set {}{}&#34;.format(new_value, unit))
+                print(f&#34;\tNew limit set {new_value}{unit}&#34;)
             return True
-        elif verbose: # print description of why the limit was not set
+        if verbose:  # print description of why the limit was not set
             if larger_than_min:
                 reason = &#34;larger&#34; if bound == &#34;max&#34; else &#34;smaller&#34;
-                print(&#34;\tNew limit NOT set: {}{unit} is {} than the instrument &#34;
-                      &#34;limit ({}{unit})&#34;.format(new_value, reason, inst_value,
-                                                unit=unit))
+                print(
+                    f&#34;\tNew limit NOT set: {new_value}{unit} is {reason} than &#34;
+                    f&#34;the instrument limit ({inst_value}{unit})&#34;
+                )
             else:
-                print(&#34;\tNew limit NOT set: {}{unit} is smaller than the &#34;
-                      &#34;current set minimum ({}{unit})&#34;.format(new_value,
-                                                              current_min,
-                                                              unit=unit))
+                print(
+                    f&#34;\tNew limit NOT set: {new_value}{unit} is smaller than the &#34;
+                    f&#34;current set minimum ({current_min}{unit})&#34;
+                )
         return False
 
     # Get currently used parameters from function generator
     def get_output_state(self):
         &#34;&#34;&#34;Returns &#34;0&#34; for &#34;OFF&#34;, &#34;1&#34; for &#34;ON&#34; &#34;&#34;&#34;
-        return self.fgen.query(&#34;OUTPut{}:STATe?&#34;.format(self.channel))
+        return self._fgen.query(f&#34;OUTPut{self._channel}:STATe?&#34;)
 
     def get_function(self):
         &#34;&#34;&#34;Returns string of function name&#34;&#34;&#34;
-        return self.fgen.query(&#34;{}FUNCtion:SHAPe?&#34;.format(self.source))
+        return self._fgen.query(f&#34;{self._source}FUNCtion:SHAPe?&#34;)
 
     def get_amplitude(self):
         &#34;&#34;&#34;Returns peak-to-peak voltage in volts&#34;&#34;&#34;
-        return float(self.fgen.query(&#34;{}VOLTage:AMPLitude?&#34;.format(self.source)))
+        return float(self._fgen.query(f&#34;{self._source}VOLTage:AMPLitude?&#34;))
 
     def get_offset(self):
         &#34;&#34;&#34;Returns offset voltage in volts&#34;&#34;&#34;
-        return float(self.fgen.query(&#34;{}VOLTage:OFFSet?&#34;.format(self.source)))
+        return float(self._fgen.query(f&#34;{self._source}VOLTage:OFFSet?&#34;))
 
     def get_frequency(self):
         &#34;&#34;&#34;Returns frequency in Hertz&#34;&#34;&#34;
-        return float(self.fgen.query(&#34;{}FREQuency?&#34;.format(self.source)))
+        return float(self._fgen.query(f&#34;{self._source}FREQuency?&#34;))
 
     # Get limits set in the channel class
     def get_frequency_lims(self):
         &#34;&#34;&#34;Returns list of min and max frequency limits&#34;&#34;&#34;
-        return [self.channel_limits[&#34;frequency lims&#34;][0][key]
-                for key in [&#34;min&#34;, &#34;max&#34;]]
+        return [self.channel_limits[&#34;frequency lims&#34;][0][key] for key in [&#34;min&#34;, &#34;max&#34;]]
 
     def get_voltage_lims(self):
         &#34;&#34;&#34;Returns list of min and max voltage limits for the current impedance&#34;&#34;&#34;
-        return [self.channel_limits[&#34;voltage lims&#34;][0][self.impedance][key]
-                for key in [&#34;min&#34;, &#34;max&#34;]]
+        return [
+            self.channel_limits[&#34;voltage lims&#34;][0][self.impedance][key]
+            for key in [&#34;min&#34;, &#34;max&#34;]
+        ]
 
     def get_amplitude_lims(self):
         &#34;&#34;&#34;Returns list of min and max amplitude limits for the current impedance&#34;&#34;&#34;
-        return [self.channel_limits[&#34;amplitude lims&#34;][0][self.impedance][key]
-                for key in [&#34;min&#34;, &#34;max&#34;]]
+        return [
+            self.channel_limits[&#34;amplitude lims&#34;][0][self.impedance][key]
+            for key in [&#34;min&#34;, &#34;max&#34;]
+        ]
 
     def get_settings(self):
         &#34;&#34;&#34;Get the settings for the channel
@@ -875,11 +1080,13 @@ class FuncGenChannel:
             function, amplitude, offset, and frequency and values tuples of
             the corresponding return and unit
         &#34;&#34;&#34;
-        return {&#34;output&#34;:    (self.state_str[self.get_output_state()], &#34;&#34;),
-                &#34;function&#34;:  (self.get_function(),  &#34;&#34;),
-                &#34;amplitude&#34;: (self.get_amplitude(), &#34;Vpp&#34;),
-                &#34;offset&#34;:    (self.get_offset(),    &#34;V&#34;),
-                &#34;frequency&#34;: (self.get_frequency(), &#34;Hz&#34;)}
+        return {
+            &#34;output&#34;: (self._state_to_str[self.get_output_state()], &#34;&#34;),
+            &#34;function&#34;: (self.get_function(), &#34;&#34;),
+            &#34;amplitude&#34;: (self.get_amplitude(), &#34;Vpp&#34;),
+            &#34;offset&#34;: (self.get_offset(), &#34;V&#34;),
+            &#34;frequency&#34;: (self.get_frequency(), &#34;Hz&#34;),
+        }
 
     def print_settings(self):
         &#34;&#34;&#34;Print the settings currently in use for the channel (Recommended
@@ -887,11 +1094,10 @@ class FuncGenChannel:
         &#34;&#34;&#34;
         settings = self.get_settings()
         longest_key = max([len(key) for key in settings.keys()])
-        print(&#34;\nCurrent settings for channel {}&#34;.format(self.channel))
+        print(&#34;\nCurrent settings for channel {}&#34;.format(self._channel))
         print(&#34;==============================&#34;)
         for key, (val, unit) in settings.items():
-            print(&#34;{:&gt;{num_char}s} {} {}&#34;.format(key, val, unit,
-                                                 num_char=longest_key))
+            print(&#34;{:&gt;{num_char}s} {} {}&#34;.format(key, val, unit, num_char=longest_key))
 
     def set_settings(self, settings):
         &#34;&#34;&#34;Set the settings of the channel with a settings dictionary. Will
@@ -908,11 +1114,11 @@ class FuncGenChannel:
         # combination of settings
         self.set_output_state(&#34;OFF&#34;)
         # Set settings according to dictionary
-        self.set_function(settings[&#39;function&#39;][0])
-        self.set_amplitude(settings[&#39;amplitude&#39;][0])
-        self.set_offset(settings[&#39;offset&#39;][0])
-        self.set_frequency(settings[&#39;frequency&#39;][0])
-        self.set_output_state(settings[&#39;output&#39;][0])
+        self.set_function(settings[&#34;function&#34;][0])
+        self.set_amplitude(settings[&#34;amplitude&#34;][0])
+        self.set_offset(settings[&#34;offset&#34;][0])
+        self.set_frequency(settings[&#34;frequency&#34;][0])
+        self.set_output_state(settings[&#34;output&#34;][0])
 
     def set_output_state(self, state):
         &#34;&#34;&#34;Enables or diables the output of the channel
@@ -926,21 +1132,22 @@ class FuncGenChannel:
         Raises
         ------
         NotSetError
-            If `self.fgen.verify_param_set` is `True` and the value after
+            If `self._fgen.verify_param_set` is `True` and the value after
             applying the set function does not match the value returned by the
             get function
         &#34;&#34;&#34;
-        err_msg = &#34;turn channel {} to state {}&#34;.format(self.channel, state)
-        self.fgen.write(&#34;OUTPut{}:STATe {}&#34;.format(self.channel, state),
-                                            custom_err_message=err_msg)
-        if self.fgen.verify_param_set:
+        err_msg = f&#34;turn channel {self._channel} to state {state}&#34;
+        self._fgen.write(
+            f&#34;OUTPut{self._channel}:STATe {state}&#34;, custom_err_message=err_msg
+        )
+        if self._fgen.verify_param_set:
             actual_state = self.get_output_state()
             if not actual_state == state:
-                msg = (&#34;Channel {} was not turned {}, it is {}.\n&#34;
-                       &#34;Error from the instrument: {}&#34;
-                       &#34;&#34;.format(self.channel, state,
-                                 self.state_str[actual_state],
-                                 self.fgen.get_error()))
+                msg = (
+                    f&#34;Channel {self._channel} was not turned {state}, it is &#34;
+                    f&#34;{self._state_to_str[actual_state]}.\n&#34;
+                    f&#34;Error from the instrument: {self._fgen.get_error()}&#34;
+                )
                 raise NotSetError(msg)
 
     def get_output(self):
@@ -969,21 +1176,22 @@ class FuncGenChannel:
         Raises
         ------
         NotSetError
-            If `self.fgen.verify_param_set` is `True` and the value after
+            If `self._fgen.verify_param_set` is `True` and the value after
             applying the set function does not match the value returned by the
             get function
         &#34;&#34;&#34;
-        cmd = &#34;{}FUNCtion:SHAPe {}&#34;.format(self.source, shape)
-        self.fgen.write(cmd, custom_err_message=&#34;set function {}&#34;.format(shape))
-        if self.fgen.verify_param_set:
+        cmd = f&#34;{self._source}FUNCtion:SHAPe {shape}&#34;
+        self._fgen.write(cmd, custom_err_message=f&#34;set function {shape}&#34;)
+        if self._fgen.verify_param_set:
             actual_shape = self.get_function()
             if not actual_shape == shape:
-                msg = (&#34;Function {} was not set on channel {}, it is {}. &#34;
-                       &#34;Check that the function name is correctly spelt. &#34;
-                       &#34;Run set_function.__doc__ to see available shapes.\n&#34;
-                       &#34;Error from the instrument: {}&#34;
-                       &#34;&#34;.format(shape, self.channel, actual_shape,
-                                 self.fgen.get_error()))
+                msg = (
+                    f&#34;Function {shape} was not set on channel {self._channel}, &#34;
+                    f&#34;it is {actual_shape}. Check that the function name is &#34;
+                    f&#34;correctly spelt. Look up `set_function.__doc__` to see &#34;
+                    f&#34;available shapes.\n Error from the instrument: &#34;
+                    f&#34;{self._fgen.get_error()}&#34;
+                )
                 raise NotSetError(msg)
 
     def set_amplitude(self, amplitude):
@@ -998,56 +1206,62 @@ class FuncGenChannel:
         Raises
         ------
         NotSetError
-            If `self.fgen.verify_param_set` is `True` and the value after
+            If `self._fgen.verify_param_set` is `True` and the value after
             applying the set function does not match the value returned by the
             get function
         &#34;&#34;&#34;
         # Check if keyword min or max is given
         if str(amplitude).lower() in [&#34;min&#34;, &#34;max&#34;]:
-            unit = &#34;&#34; # no unit for MIN/MAX
+            unit = &#34;&#34;  # no unit for MIN/MAX
             # Look up what the limit is for this keyword
-            amplitude = self.channel_limits[&#34;amplitude lims&#34;][0][self.impedance][str(amplitude).lower()]
+            amplitude = self.channel_limits[&#34;amplitude lims&#34;][0][self.impedance][
+                str(amplitude).lower()
+            ]
         else:
             unit = &#34;Vpp&#34;
             # Check if the given amplitude is within the current limits
             min_ampl, max_ampl = self.get_amplitude_lims()
             if amplitude &lt; min_ampl or amplitude &gt; max_ampl:
-                msg = (&#34;Could not set the amplitude {}{unit} as it is not &#34;
-                       &#34;within the amplitude limits set for the instrument &#34;
-                       &#34;[{}, {}]{unit}&#34;.format(amplitude, min_ampl, max_ampl,
-                                               unit=unit))
+                msg = (
+                    f&#34;Could not set the amplitude {amplitude}{unit} as it &#34;
+                    f&#34;is not within the amplitude limits set for the instrument &#34;
+                    f&#34;[{min_ampl}, {max_ampl}]{unit}&#34;
+                )
                 raise NotSetError(msg)
         # Check that the new amplitude will not violate voltage limits
         min_volt, max_volt = self.get_voltage_lims()
         current_offset = self.get_offset()
-        if (amplitude/2-current_offset &lt; min_volt or
-            amplitude/2+current_offset &gt; max_volt):
-            msg = (&#34;Could not set the amplitude {}{unit} as the amplitude &#34;
-                   &#34;combined with the offset ({}V) will be outside the &#34;
-                   &#34;absolute voltage limits [{}, {}]{unit}&#34;
-                   &#34;&#34;.format(amplitude, current_offset, min_volt, max_volt,
-                             unit=unit))
+        if (
+            amplitude / 2 - current_offset &lt; min_volt
+            or amplitude / 2 + current_offset &gt; max_volt
+        ):
+            msg = (
+                f&#34;Could not set the amplitude {amplitude}{unit} as the amplitude &#34;
+                f&#34;combined with the offset ({current_offset}V) will be outside the &#34;
+                f&#34;absolute voltage limits [{min_volt}, {max_volt}]{unit}&#34;
+            )
             raise NotSetError(msg)
         # Set the amplitude
-        cmd = &#34;{}VOLTage:LEVel {}{}&#34;.format(self.source, amplitude, unit)
-        err_msg = &#34;set amplitude {}{}&#34;.format(amplitude, unit)
-        self.fgen.write(cmd, custom_err_message=err_msg)
+        cmd = f&#34;{self._source}VOLTage:LEVel {amplitude}{unit}&#34;
+        err_msg = f&#34;set amplitude {amplitude}{unit}&#34;
+        self._fgen.write(cmd, custom_err_message=err_msg)
         # Verify that the amplitude has been set
-        if self.fgen.verify_param_set:
+        if self._fgen.verify_param_set:
             actual_amplitude = self.get_amplitude()
             # Multiply with the appropriate factor according to SI prefix, or
             # if string is empty, use the value looked up from channel_limits earlier
             if not unit == &#34;&#34;:
-                check_amplitude = amplitude*self.SI_prefix_to_factor(unit)
+                check_amplitude = amplitude * _SI_prefix_to_factor(unit)
             else:
-                 check_amplitude = amplitude
+                check_amplitude = amplitude
             if not actual_amplitude == check_amplitude:
-                msg = (&#34;Amplitude {}{} was not set on channel {}, it is &#34;
-                       &#34;{}Vpp. Check that the number is within the possible &#34;
-                       &#34;range and in the correct format.\nError from the &#34;
-                       &#34;instrument: {}&#34;
-                       &#34;&#34;.format(amplitude, unit, self.channel,
-                                 actual_amplitude, self.fgen.get_error()))
+                msg = (
+                    f&#34;Amplitude {amplitude}{unit} was not set on channel &#34;
+                    f&#34;{self._channel}, it is {actual_amplitude}Vpp. Check that &#34;
+                    f&#34; the number is within the possible range and in the &#34;
+                    f&#34;correct format.\nError from the instrument: &#34;
+                    f&#34;{self._fgen.get_error()}&#34;
+                )
                 raise NotSetError(msg)
 
     def set_offset(self, offset, unit=&#34;V&#34;):
@@ -1062,144 +1276,114 @@ class FuncGenChannel:
         Raises
         ------
         NotSetError
-            If `self.fgen.verify_param_set` is `True` and the value after
+            If `self._fgen.verify_param_set` is `True` and the value after
             applying the set function does not match the value returned by the
             get function
         &#34;&#34;&#34;
         # Check that the new offset will not violate voltage limits
         min_volt, max_volt = self.get_voltage_lims()
         current_amplitude = self.get_amplitude()
-        if (current_amplitude/2-offset &lt; min_volt or
-            current_amplitude/2+offset &gt; max_volt):
-            msg = (&#34;Could not set the offset {}{unit} as the offset combined&#34;
-                   &#34;with the amplitude ({}V) will be outside the absolute &#34;
-                   &#34;voltage limits [{}, {}]{unit}&#34;.format(offset,
-                                                         current_amplitude,
-                                                         min_volt, max_volt,
-                                                         unit=unit))
+        offset = _SI_prefix_to_factor(unit) * offset
+        if (
+            current_amplitude / 2 - offset &lt; min_volt
+            or current_amplitude / 2 + offset &gt; max_volt
+        ):
+            msg = (
+                f&#34;Could not set the offset {offset}V as the offset combined &#34;
+                f&#34;with the amplitude ({current_amplitude}V) will be outside &#34;
+                f&#34;the absolute voltage limits [{min_volt}, {max_volt}]V&#34;
+            )
             raise NotSetError(msg)
         # Set the offset
-        cmd = &#34;{}VOLTage:LEVel:OFFSet {}{}&#34;.format(self.source, offset, unit)
-        err_msg = &#34;set offset {}{}&#34;.format(offset, unit)
-        self.fgen.write(cmd, custom_err_message=err_msg)
+        cmd = f&#34;{self._source}VOLTage:LEVel:OFFSet {offset}{unit}&#34;
+        err_msg = f&#34;set offset {offset}{unit}&#34;
+        self._fgen.write(cmd, custom_err_message=err_msg)
         # Verify that the offset has been set
-        if self.fgen.verify_param_set:
+        if self._fgen.verify_param_set:
             actual_offset = self.get_offset()
             # Multiply with the appropriate factor according to SI prefix
-            check_offset = offset*self.SI_prefix_to_factor(unit)
+            check_offset = offset * _SI_prefix_to_factor(unit)
             if not actual_offset == check_offset:
-                msg = (&#34;Offset {}{} was not set on channel {}, it is {}V. &#34;
-                       &#34;Check that the number is within the possible range and &#34;
-                       &#34;in the correct format.\nError from the instrument: {}&#34;
-                       &#34;&#34;.format(offset, unit, self.channel, actual_offset,
-                                 self.fgen.get_error()))
+                msg = (
+                    f&#34;Offset {offset}{unit} was not set on channel &#34;
+                    f&#34;{self._channel}, it is {actual_offset}V. Check that the &#34;
+                    f&#34;number is within the possible range and in the correct &#34;
+                    f&#34;format.\nError from the instrument: {self._fgen.get_error()}&#34;
+                )
                 raise NotSetError(msg)
 
     def set_frequency(self, freq, unit=&#34;Hz&#34;):
-        &#34;&#34;&#34;Set the frequency in Hertz (or kHz, MHz, see options)
+        &#34;&#34;&#34;Set the frequency in Hertz (or mHz, kHz, MHz, see options)
 
         Parameters
         ----------
         freq : float
             The resolution is 1 μHz or 12 digits.
-        unit : {Hz, kHz, MHz}, default Hz
+        unit : {mHz, Hz, kHz, MHz}, default Hz
 
         Raises
         ------
         NotSetError
-            If `self.fgen.verify_param_set` is `True` and the value after
+            If `self._fgen.verify_param_set` is `True` and the value after
             applying the set function does not match the value returned by the
             get function
         &#34;&#34;&#34;
-        if str(freq).lower() in [&#34;min&#34;, &#34;max&#34;]: # handle min and max keywords
-            unit = &#34;&#34; # no unit for MIN/MAX
+        if str(freq).lower() in [&#34;min&#34;, &#34;max&#34;]:  # handle min and max keywords
+            unit = &#34;&#34;  # no unit for MIN/MAX
             # Look up what the limit is for this keyword
             freq = self.channel_limits[&#34;frequency lims&#34;][0][str(freq).lower()]
         else:
             # Check if the given frequency is within the current limits
             min_freq, max_freq = self.get_frequency_lims()
+            freq = _SI_prefix_to_factor(unit) * freq
             if freq &lt; min_freq or freq &gt; max_freq:
-                msg = (&#34;Could not set the frequency {}{} as it is not within &#34;
-                       &#34;the frequency limits set for the instrument [{}, {}]&#34;
-                       &#34;Hz&#34;.format(freq, unit, min_freq, max_freq))
+                msg = (
+                    f&#34;Could not set the frequency {freq}Hz as it is not &#34;
+                    f&#34;within the frequency limits set for the instrument &#34;
+                    f&#34;[{min_freq}, {max_freq}]Hz&#34;
+                )
                 raise NotSetError(msg)
-        # Check that the new amplitude will not violate voltage limits
-        min_volt, max_volt = self.get_voltage_lims()
         # Set the frequency
-        self.fgen.write(&#34;{}FREQuency:FIXed {}{}&#34;.format(self.source, freq, unit),
-                            custom_err_message=&#34;set frequency {}{}&#34;.format(freq, unit))
+        self._fgen.write(
+            f&#34;{self._source}FREQuency:FIXed {freq}{unit}&#34;,
+            custom_err_message=f&#34;set frequency {freq}{unit}&#34;,
+        )
         # Verify that the amplitude has been set
-        if self.fgen.verify_param_set:
+        if self._fgen.verify_param_set:
             actual_freq = self.get_frequency()
             # Multiply with the appropriate factor according to SI prefix, or
             # if string is empty, use the value looked up from channel_limits earlier
             if not unit == &#34;&#34;:
-                check_freq = freq*self.SI_prefix_to_factor(unit)
+                check_freq = freq * _SI_prefix_to_factor(unit)
             else:
-                check_freq =  freq
+                check_freq = freq
             if not actual_freq == check_freq:
-                msg = (&#34;Frequency {}{} was not set on channel {}, it is {}Hz. &#34;
-                &#34;Check that the number is within the possible range and in &#34;
-                &#34;the correct format.\nError from the instrument: {}&#34;
-                &#34;&#34;.format(freq, unit, self.channel, actual_freq,
-                            self.fgen.get_error()))
+                msg = (
+                    f&#34;Frequency {freq}{unit} was not set on channel {self._channel}&#34;
+                    f&#34;, it is {actual_freq}Hz. Check that the number is within &#34;
+                    f&#34;the possible range and in the correct format.\nError &#34;
+                    f&#34;from the instrument: {self._fgen.get_error()}&#34;
+                )
                 raise NotSetError(msg)
 
-
-    ## ~~~~~~~~~~~~~~~~~~~~~~~ AUXILLIARY ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ##
-
-    @staticmethod
-    def SI_prefix_to_factor(unit):
-        &#34;&#34;&#34;Convert an SI prefix to a numerical factor
-
-        Parameters
-        ----------
-        unit : str
-            The unit whose first character is checked against the list of
-            prefactors {&#34;M&#34;: 1e6, &#34;k&#34;: 1e3, &#34;m&#34;: 1e-3}
-
-        Returns
-        -------
-        factor : float or `None`
-            The appropriate factor or 1 if not found in the list, or `None`
-            if the unit string is empty
-        &#34;&#34;&#34;
-        # SI prefix to numerical value
-        SI_conversion = {&#34;M&#34;:1e6, &#34;k&#34;:1e3, &#34;m&#34;:1e-3}
-        try:  # using the unit&#39;s first character as key in the dictionary
-            factor = SI_conversion[unit[0]]
-        except KeyError:  # if the entry does not exist
-            factor = 1
-        except IndexError:  # if the unit string is empty
-            factor = None
-        return factor
-
-
-## ~~~~~~~~~~~~~~~~~~~~~~~~~~~ ERROR CLASSES ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ##
-
-class NotSetError(Exception):
-    &#34;&#34;&#34;Error for when a value cannot be written to the instrument&#34;&#34;&#34;
-
-
-class NotCompatibleError(Exception):
-    &#34;&#34;&#34;Error for when the instrument is not compatible with this module&#34;&#34;&#34;
 
 
 ## ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ EXAMPLES ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ##
 
+
 def example_basic_control(address):
     &#34;&#34;&#34;Example showing how to connect, and the most basic control of the
-    instrument parameteres&#34;&#34;&#34;
+    instrument parameters&#34;&#34;&#34;
     print(&#34;\n\n&#34;, example_basic_control.__doc__)
     with FuncGen(address) as fgen:
-      fgen.ch1.set_function(&#34;SIN&#34;)
-      fgen.ch1.set_frequency(25, unit=&#34;Hz&#34;)
-      fgen.ch1.set_offset(50, unit=&#34;mV&#34;)
-      fgen.ch1.set_amplitude(0.002)
-      fgen.ch1.set_output(&#34;ON&#34;)
-      fgen.ch2.set_output(&#34;OFF&#34;)
-      # Alternatively fgen.ch1.print_settings() to show from one channel only
-      fgen.print_settings()
+        fgen.ch1.set_function(&#34;SIN&#34;)
+        fgen.ch1.set_frequency(25, unit=&#34;Hz&#34;)
+        fgen.ch1.set_offset(50, unit=&#34;mV&#34;)
+        fgen.ch1.set_amplitude(0.002)
+        fgen.ch1.set_output(&#34;ON&#34;)
+        fgen.ch2.set_output(&#34;OFF&#34;)
+        # Alternatively fgen.ch1.print_settings() to show from one channel only
+        fgen.print_settings()
 
 
 def example_change_settings(address):
@@ -1244,50 +1428,52 @@ def example_changing_limits(address):
             print(err)
 
 
-def example_set_and_use_custom_waveform(fgen=None, address=None, channel=1,
-                                        plot_signal=True):
+def example_set_and_use_custom_waveform(
+    fgen=None, address=None, channel=1, plot_signal=True
+):
     &#34;&#34;&#34;Example showing a waveform being created, transferred to the instrument,
     and applied to a channel&#34;&#34;&#34;
     print(&#34;\n\n&#34;, example_set_and_use_custom_waveform.__doc__)
     # Create a signal
-    x = np.linspace(0, 4*np.pi, 8000)
-    signal = np.sin(x)+x/5
-    if plot_signal: # plot the signal for visual control
+    x = np.linspace(0, 4 * np.pi, 8000)
+    signal = np.sin(x) + x / 5
+    if plot_signal:  # plot the signal for visual control
         import matplotlib.pyplot as plt
+
         plt.plot(signal)
         plt.show()
     # Create initialise fgen if it was not supplied
     if fgen is None:
         fgen = FuncGen(address)
-        close_fgen = True # specify that it should be closed at end of function
+        close_fgen = True  # specify that it should be closed at end of function
     else:
-        close_fgen = False # do not close the supplied fgen at end
+        close_fgen = False  # do not close the supplied fgen at end
     print(&#34;Current waveform catalogue&#34;)
     for i, wav in enumerate(fgen.get_waveform_catalogue()):
-        print(&#34;  {}: {}&#34;.format(i, wav))
+        print(f&#34;  {i}: {wav}&#34;)
     # Transfer the waveform
     fgen.set_custom_waveform(signal, memory_num=5, verify=True)
     print(&#34;New waveform catalogue:&#34;)
     for i, wav in enumerate(fgen.get_waveform_catalogue()):
-        print(&#34;  {}: {}&#34;.format(i, wav))
-    print(&#34;Set new wavefrom to channel {}..&#34;.format(channel), end=&#34; &#34;)
-    fgen.channels[channel-1].set_output_state(&#34;OFF&#34;)
-    fgen.channels[channel-1].set_function(&#34;USER5&#34;)
+        print(f&#34;  {i}: {wav}&#34;)
+    print(f&#34;Set new wavefrom to channel {channel}..&#34;, end=&#34; &#34;)
+    fgen.channels[channel - 1].set_output_state(&#34;OFF&#34;)
+    fgen.channels[channel - 1].set_function(&#34;USER5&#34;)
     print(&#34;ok&#34;)
     # Print current settings
     fgen.get_settings()
-    if close_fgen: fgen.close()
+    if close_fgen:
+        fgen.close()
 
 
 ## ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ MAIN FUNCTION ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ##
 
-if __name__ == &#39;__main__&#39;:
-    address = &#39;USB0::0x0699::0x0353::1731975::INSTR&#39;
-    example_basic_control(address)
-    example_change_settings(address)
-    example_lock_frequencies(address)
-    example_changing_limits(address)
-    with FuncGen(address) as fgen:
+if __name__ == &#34;__main__&#34;:
+    example_basic_control(_VISA_ADDRESS)
+    example_change_settings(_VISA_ADDRESS)
+    example_lock_frequencies(_VISA_ADDRESS)
+    example_changing_limits(_VISA_ADDRESS)
+    with FuncGen(_VISA_ADDRESS) as fgen:
         example_set_and_use_custom_waveform(fgen)</code></pre>
 </details>
 </section>
@@ -1302,33 +1488,33 @@ if __name__ == &#39;__main__&#39;:
 <span>def <span class="ident">example_basic_control</span></span>(<span>address)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Example showing how to connect, and the most basic control of the
-instrument parameteres</p></section>
+<div class="desc"><p>Example showing how to connect, and the most basic control of the
+instrument parameters</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">def example_basic_control(address):
     &#34;&#34;&#34;Example showing how to connect, and the most basic control of the
-    instrument parameteres&#34;&#34;&#34;
+    instrument parameters&#34;&#34;&#34;
     print(&#34;\n\n&#34;, example_basic_control.__doc__)
     with FuncGen(address) as fgen:
-      fgen.ch1.set_function(&#34;SIN&#34;)
-      fgen.ch1.set_frequency(25, unit=&#34;Hz&#34;)
-      fgen.ch1.set_offset(50, unit=&#34;mV&#34;)
-      fgen.ch1.set_amplitude(0.002)
-      fgen.ch1.set_output(&#34;ON&#34;)
-      fgen.ch2.set_output(&#34;OFF&#34;)
-      # Alternatively fgen.ch1.print_settings() to show from one channel only
-      fgen.print_settings()</code></pre>
+        fgen.ch1.set_function(&#34;SIN&#34;)
+        fgen.ch1.set_frequency(25, unit=&#34;Hz&#34;)
+        fgen.ch1.set_offset(50, unit=&#34;mV&#34;)
+        fgen.ch1.set_amplitude(0.002)
+        fgen.ch1.set_output(&#34;ON&#34;)
+        fgen.ch2.set_output(&#34;OFF&#34;)
+        # Alternatively fgen.ch1.print_settings() to show from one channel only
+        fgen.print_settings()</code></pre>
 </details>
 </dd>
 <dt id="tektronix_func_gen.example_change_settings"><code class="name flex">
 <span>def <span class="ident">example_change_settings</span></span>(<span>address)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Example showing how to get the current settings of the instrument,
-store them, change a setting and then restore the initial settings</p></section>
+<div class="desc"><p>Example showing how to get the current settings of the instrument,
+store them, change a setting and then restore the initial settings</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -1353,7 +1539,7 @@ store them, change a setting and then restore the initial settings</p></section>
 <span>def <span class="ident">example_changing_limits</span></span>(<span>address)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Example showing how limits can be read and changed</p></section>
+<div class="desc"><p>Example showing how limits can be read and changed</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -1379,8 +1565,8 @@ store them, change a setting and then restore the initial settings</p></section>
 <span>def <span class="ident">example_lock_frequencies</span></span>(<span>address)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Example showing the frequency being set to 10Hz and then the frequency
-lock enabled, using the frequency at ch1 as the common frequency</p></section>
+<div class="desc"><p>Example showing the frequency being set to 10Hz and then the frequency
+lock enabled, using the frequency at ch1 as the common frequency</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -1398,45 +1584,48 @@ lock enabled, using the frequency at ch1 as the common frequency</p></section>
 <span>def <span class="ident">example_set_and_use_custom_waveform</span></span>(<span>fgen=None, address=None, channel=1, plot_signal=True)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Example showing a waveform being created, transferred to the instrument,
-and applied to a channel</p></section>
+<div class="desc"><p>Example showing a waveform being created, transferred to the instrument,
+and applied to a channel</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def example_set_and_use_custom_waveform(fgen=None, address=None, channel=1,
-                                        plot_signal=True):
+<pre><code class="python">def example_set_and_use_custom_waveform(
+    fgen=None, address=None, channel=1, plot_signal=True
+):
     &#34;&#34;&#34;Example showing a waveform being created, transferred to the instrument,
     and applied to a channel&#34;&#34;&#34;
     print(&#34;\n\n&#34;, example_set_and_use_custom_waveform.__doc__)
     # Create a signal
-    x = np.linspace(0, 4*np.pi, 8000)
-    signal = np.sin(x)+x/5
-    if plot_signal: # plot the signal for visual control
+    x = np.linspace(0, 4 * np.pi, 8000)
+    signal = np.sin(x) + x / 5
+    if plot_signal:  # plot the signal for visual control
         import matplotlib.pyplot as plt
+
         plt.plot(signal)
         plt.show()
     # Create initialise fgen if it was not supplied
     if fgen is None:
         fgen = FuncGen(address)
-        close_fgen = True # specify that it should be closed at end of function
+        close_fgen = True  # specify that it should be closed at end of function
     else:
-        close_fgen = False # do not close the supplied fgen at end
+        close_fgen = False  # do not close the supplied fgen at end
     print(&#34;Current waveform catalogue&#34;)
     for i, wav in enumerate(fgen.get_waveform_catalogue()):
-        print(&#34;  {}: {}&#34;.format(i, wav))
+        print(f&#34;  {i}: {wav}&#34;)
     # Transfer the waveform
     fgen.set_custom_waveform(signal, memory_num=5, verify=True)
     print(&#34;New waveform catalogue:&#34;)
     for i, wav in enumerate(fgen.get_waveform_catalogue()):
-        print(&#34;  {}: {}&#34;.format(i, wav))
-    print(&#34;Set new wavefrom to channel {}..&#34;.format(channel), end=&#34; &#34;)
-    fgen.channels[channel-1].set_output_state(&#34;OFF&#34;)
-    fgen.channels[channel-1].set_function(&#34;USER5&#34;)
+        print(f&#34;  {i}: {wav}&#34;)
+    print(f&#34;Set new wavefrom to channel {channel}..&#34;, end=&#34; &#34;)
+    fgen.channels[channel - 1].set_output_state(&#34;OFF&#34;)
+    fgen.channels[channel - 1].set_function(&#34;USER5&#34;)
     print(&#34;ok&#34;)
     # Print current settings
     fgen.get_settings()
-    if close_fgen: fgen.close()</code></pre>
+    if close_fgen:
+        fgen.close()</code></pre>
 </details>
 </dd>
 </dl>
@@ -1446,15 +1635,15 @@ and applied to a channel</p></section>
 <dl>
 <dt id="tektronix_func_gen.FuncGen"><code class="flex name class">
 <span>class <span class="ident">FuncGen</span></span>
-<span>(</span><span>address, impedance=('highZ', 'highZ'), timeout=5000, verify_param_set=False, override_compatibility=False, verbose=True)</span>
+<span>(</span><span>visa_address, impedance=('highZ', 'highZ'), timeout=5000, verify_param_set=False, override_compatibility=False, verbose=True)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Class for interacting with Tektronix function generator</p>
+<div class="desc"><p>Class for interacting with Tektronix function generator</p>
 <h2 id="parameters">Parameters</h2>
 <dl>
-<dt><strong><code>address</code></strong> :&ensp;<code>str</code></dt>
-<dd>VISA address of insrument</dd>
-<dt><strong><code>impedance</code></strong> :&ensp;<code>tuple</code> of {<code>"highZ"</code>, <code>"50ohm"</code>}, default (<code>"highZ"</code>,)*<code>2</code></dt>
+<dt><strong><code>visa_address</code></strong> :&ensp;<code>str</code></dt>
+<dd>VISA address of the insrument</dd>
+<dt><strong><code>impedance</code></strong> :&ensp;<code>tuple</code> of <code>{"highZ", "50ohm"}</code>, default <code>("highZ",)*2</code></dt>
 <dd>Determines voltage limits associated with high impedance (whether the
 instrument is using 50ohm or high Z cannot be controlled through VISA).
 For example <code>("highZ", "50ohm")</code> for to use high Z for ch1 and
@@ -1467,42 +1656,23 @@ For example <code>("highZ", "50ohm")</code> for to use high Z for ch1 and
 <dd>Choose whether to print information such as model upon connecting etc</dd>
 <dt><strong><code>override_compatibility</code></strong> :&ensp;<code>bool</code>, default <code>False</code></dt>
 <dd>If the instrument limits for the model connected to are not known
-<a title="tektronix_func_gen.NotCompatibleError" href="#tektronix_func_gen.NotCompatibleError"><code>NotCompatibleError</code></a> will be raised. To override and use AFG1022 limits,
+<code><a title="tektronix_func_gen.NotCompatibleError" href="#tektronix_func_gen.NotCompatibleError">NotCompatibleError</a></code> will be raised. To override and use AFG1022 limits,
 set to <code>True</code>. Note that this might lead to unexpected behaviour for
 custom waveforms and 'MIN'/'MAX' keywords.</dd>
 </dl>
 <h2 id="attributes">Attributes</h2>
 <dl>
-<dt><strong><code>address</code></strong> :&ensp;<code>str</code></dt>
+<dt><strong><code>_visa_address</code></strong> :&ensp;<code>str</code></dt>
 <dd>The VISA address of the instrument</dd>
-<dt><strong><code>id</code></strong> :&ensp;<code>str</code></dt>
+<dt><strong><code>_id</code></strong> :&ensp;<code>str</code></dt>
 <dd>Comma separated string with maker, model, serial and firmware of
 the instrument</dd>
-<dt><strong><code>inst</code></strong> :&ensp;<code>pyvisa.resources.Resource</code></dt>
+<dt><strong><code>_inst</code></strong> :&ensp;<code>pyvisa.resources.Resource</code></dt>
 <dd>The PyVISA resource</dd>
-<dt><strong><code>channels</code></strong> :&ensp;<code>tuple</code> of <a title="tektronix_func_gen.FuncGenChannel" href="#tektronix_func_gen.FuncGenChannel"><code>FuncGenChannel</code></a></dt>
-<dd>Objects to control the channels</dd>
-<dt><strong><code>ch1</code></strong> :&ensp;<a title="tektronix_func_gen.FuncGenChannel" href="#tektronix_func_gen.FuncGenChannel"><code>FuncGenChannel</code></a></dt>
-<dd>Short hand for <code>channels[0]</code> Object to control channel 1</dd>
-<dt><strong><code>ch2</code></strong> :&ensp;<a title="tektronix_func_gen.FuncGenChannel" href="#tektronix_func_gen.FuncGenChannel"><code>FuncGenChannel</code></a></dt>
-<dd>Short hand for <code>channels[1]</code> Object to control channel 2</dd>
-<dt><strong><code>instrument_limits</code></strong> :&ensp;<code>dict</code></dt>
-<dd>Contains the following keys with subdictionaries
-<code>frequency lims</code>
-Containing the frequency limits for the instrument where the keys
-"min" and "max" have values corresponding to minimum and maximum
-frequencies in Hz
-<code>voltage lims</code>
-Contains the maximum absolute voltage the instrument can output
-for the keys "50ohm" and "highZ" according to the impedance setting
-<code>amplitude lims</code>
-Contains the smallest and largest possible amplitudes where the
-keys "50ohm" and "highZ" will have subdictionaries with keys
-"min" and "max"</dd>
-<dt><strong><code>arbitrary_waveform_length</code></strong> :&ensp;<code>list</code></dt>
+<dt><strong><code>_arbitrary_waveform_length</code></strong> :&ensp;<code>list</code></dt>
 <dd>The permitted minimum and maximum length of an arbitrary waveform,
 e.g. [2, 8192]</dd>
-<dt><strong><code>arbitrary_waveform_resolution</code></strong> :&ensp;<code>int</code></dt>
+<dt><strong><code>_arbitrary_waveform_resolution</code></strong> :&ensp;<code>int</code></dt>
 <dd>The vertical resolution of the arbitrary waveform, for instance 14 bit
 =&gt; 2**14-1 = 16383</dd>
 </dl>
@@ -1510,22 +1680,22 @@ e.g. [2, 8192]</dd>
 <dl>
 <dt><code>pyvisa.Error</code></dt>
 <dd>If the supplied VISA address cannot be connected to</dd>
-<dt><a title="tektronix_func_gen.NotCompatibleError" href="#tektronix_func_gen.NotCompatibleError"><code>NotCompatibleError</code></a></dt>
+<dt><code><a title="tektronix_func_gen.NotCompatibleError" href="#tektronix_func_gen.NotCompatibleError">NotCompatibleError</a></code></dt>
 <dd>If the instrument limits for the model connected to are not known
 (Call the class with <code>override_compatibility=True</code> to override and
 use AFG1022 limits)</dd>
-</dl></section>
+</dl></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">class FuncGen():
+<pre><code class="python">class FuncGen:
     &#34;&#34;&#34;Class for interacting with Tektronix function generator
 
     Parameters
     ----------
-    address : str
-        VISA address of insrument
+    visa_address : str
+        VISA address of the insrument
     impedance : tuple of {&#34;highZ&#34;, &#34;50ohm&#34;}, default (&#34;highZ&#34;,)*2
         Determines voltage limits associated with high impedance (whether the
         instrument is using 50ohm or high Z cannot be controlled through VISA).
@@ -1545,36 +1715,17 @@ use AFG1022 limits)</dd>
 
     Attributes
     ----------
-    address : str
+    _visa_address : str
         The VISA address of the instrument
-    id : str
+    _id : str
         Comma separated string with maker, model, serial and firmware of
         the instrument
-    inst : `pyvisa.resources.Resource`
+    _inst : `pyvisa.resources.Resource`
         The PyVISA resource
-    channels : tuple of FuncGenChannel
-        Objects to control the channels
-    ch1 : FuncGenChannel
-        Short hand for `channels[0]` Object to control channel 1
-    ch2 : FuncGenChannel
-        Short hand for `channels[1]` Object to control channel 2
-    instrument_limits : dict
-        Contains the following keys with subdictionaries
-        `frequency lims`
-            Containing the frequency limits for the instrument where the keys
-            &#34;min&#34; and &#34;max&#34; have values corresponding to minimum and maximum
-            frequencies in Hz
-        `voltage lims`
-            Contains the maximum absolute voltage the instrument can output
-            for the keys &#34;50ohm&#34; and &#34;highZ&#34; according to the impedance setting
-        `amplitude lims`
-            Contains the smallest and largest possible amplitudes where the
-            keys &#34;50ohm&#34; and &#34;highZ&#34; will have subdictionaries with keys
-            &#34;min&#34; and &#34;max&#34;
-    arbitrary_waveform_length : list
+    _arbitrary_waveform_length : list
         The permitted minimum and maximum length of an arbitrary waveform,
         e.g. [2, 8192]
-    arbitrary_waveform_resolution : int
+    _arbitrary_waveform_resolution : int
         The vertical resolution of the arbitrary waveform, for instance 14 bit
         =&gt; 2**14-1 = 16383
 
@@ -1588,38 +1739,70 @@ use AFG1022 limits)</dd>
         use AFG1022 limits)
     &#34;&#34;&#34;
 
-    def __init__(self, address, impedance=(&#34;highZ&#34;,)*2, timeout=5000,
-                 verify_param_set=False, override_compatibility=False,
-                 verbose=True):
-        self.override_compatibility = override_compatibility
-        self.address = address
-        self.timeout = timeout
+    instrument_limits = {}
+    &#34;&#34;&#34;dict: Contains the following keys with subdictionaries
+
+        - `frequency lims`
+          Containing the frequency limits for the instrument where the keys
+          &#34;min&#34; and &#34;max&#34; have values corresponding to minimum and maximum
+          frequencies in Hz
+        - `voltage lims`
+          Contains the maximum absolute voltage the instrument can output
+          for the keys &#34;50ohm&#34; and &#34;highZ&#34; according to the impedance setting
+        - `amplitude lims`
+          Contains the smallest and largest possible amplitudes where the
+          keys &#34;50ohm&#34; and &#34;highZ&#34; will have subdictionaries with keys
+          &#34;min&#34; and &#34;max&#34;
+    &#34;&#34;&#34;
+
+    def __init__(
+        self,
+        visa_address,
+        impedance=(&#34;highZ&#34;,) * 2,
+        timeout=5000,
+        verify_param_set=False,
+        override_compatibility=False,
+        verbose=True,
+    ):
+        self._override_compatibility = override_compatibility
+        self._visa_address = visa_address
+        self._timeout = timeout
         self.verify_param_set = verify_param_set
+        &#34;&#34;&#34;bool:  Verify that a value is successfully set after executing a set function&#34;&#34;&#34;
         self.verbose = verbose
+        &#34;&#34;&#34;bool: Choose whether to print information such as model upon connecting etc&#34;&#34;&#34;
         try:
             rm = pyvisa.ResourceManager()
-            self.inst = rm.open_resource(address)
+            self._inst = rm.open_resource(visa_address)
         except pyvisa.Error:
-            print(&#34;\nVisaError: Could not connect to \&#39;{}\&#39;&#34;.format(address))
+            print(f&#34;\nVisaError: Could not connect to &#39;{visa_address}&#39;&#34;)
             raise
-        self.inst.timeout = self.timeout
+        self._inst.timeout = self._timeout
         # Clear all the event registers and queues used in the instrument
         # status and event reporting system
         self.write(&#34;*CLS&#34;)
         # Get information about the connected device
-        self.id = self.query(&#34;*IDN?&#34;)
+        self._id = self.query(&#34;*IDN?&#34;)
         # Second query might be needed due to unknown reason
         # (suspecting *CLS does something weird)
-        if self.id == &#39;&#39;:
-            self.id = self.query(&#34;*IDN?&#34;)
-        self.maker, self.model, self.serial = self.id.split(&#34;,&#34;)[:3]
+        if self._id == &#34;&#34;:
+            self._id = self.query(&#34;*IDN?&#34;)
+        self._maker, self._model, self._serial = self._id.split(&#34;,&#34;)[:3]
         if self.verbose:
-            print(&#34;Connected to {} model {}, serial&#34;
-                  &#34; {}&#34;.format(self.maker, self.model, self.serial))
-        self.initialise_model_properties()
-        self.channels = (self.spawn_channel(1, impedance[0]),
-                         self.spawn_channel(2, impedance[1]))
-        self.ch1, self.ch2 = self.channels
+            print(
+                &#34;Connected to {} model {}, serial&#34;
+                &#34; {}&#34;.format(self._maker, self._model, self._serial)
+            )
+        self._initialise_model_properties()
+        self.channels = (
+            self._spawn_channel(1, impedance[0]),
+            self._spawn_channel(2, impedance[1]),
+        )
+        &#34;&#34;&#34;tuple of `FuncGenChannel`: Objects to control the channels&#34;&#34;&#34;
+        self.ch1 = self.channels[0]
+        &#34;&#34;&#34;`FuncGenChannel`: Short hand for `channels[0]` Object to control channel 1&#34;&#34;&#34;
+        self.ch2 = self.channels[1]
+        &#34;&#34;&#34;`FuncGenChannel`: Short hand for `channels[1]` Object to control channel 2&#34;&#34;&#34;
 
     def __enter__(self, **kwargs):
         # The kwargs will be passed on to __init__
@@ -1633,9 +1816,9 @@ use AFG1022 limits)</dd>
 
     def close(self):
         &#34;&#34;&#34;Close the connection to the instrument&#34;&#34;&#34;
-        self.inst.close()
+        self._inst.close()
 
-    def initialise_model_properties(self):
+    def _initialise_model_properties(self):
         &#34;&#34;&#34;Initialises the limits of what the instrument can handle according
         to the instrument model
 
@@ -1645,21 +1828,31 @@ use AFG1022 limits)</dd>
             If the connected model is not necessarily compatible with this
             package, slimits are not known.
         &#34;&#34;&#34;
-        if self.model == &#39;AFG1022&#39; or self.override_compatibility:
+        if self._model == &#34;AFG1022&#34; or self._override_compatibility:
             self.instrument_limits = {
                 &#34;frequency lims&#34;: ({&#34;min&#34;: 1e-6, &#34;max&#34;: 25e6}, &#34;Hz&#34;),
-                &#34;voltage lims&#34;:   ({&#34;50ohm&#34;: {&#34;min&#34;: -5, &#34;max&#34;: 5},
-                                    &#34;highZ&#34;: {&#34;min&#34;: -10, &#34;max&#34;: 10}}, &#34;V&#34;),
-                &#34;amplitude lims&#34;: ({&#34;50ohm&#34;: {&#34;min&#34;: 0.001, &#34;max&#34;: 10},
-                                    &#34;highZ&#34;: {&#34;min&#34;: 0.002, &#34;max&#34;: 20}}, &#34;Vpp&#34;)}
-            self.arbitrary_waveform_length = [2, 8192]  # min length, max length
-            self.arbitrary_waveform_resolution = 16383  # 14 bit
+                &#34;voltage lims&#34;: (
+                    {&#34;50ohm&#34;: {&#34;min&#34;: -5, &#34;max&#34;: 5}, &#34;highZ&#34;: {&#34;min&#34;: -10, &#34;max&#34;: 10}},
+                    &#34;V&#34;,
+                ),
+                &#34;amplitude lims&#34;: (
+                    {
+                        &#34;50ohm&#34;: {&#34;min&#34;: 0.001, &#34;max&#34;: 10},
+                        &#34;highZ&#34;: {&#34;min&#34;: 0.002, &#34;max&#34;: 20},
+                    },
+                    &#34;Vpp&#34;,
+                ),
+            }
+            self._arbitrary_waveform_length = [2, 8192]  # min length, max length
+            self._arbitrary_waveform_resolution = 16383  # 14 bit
         else:
-            msg = (&#34;Model {} not supported, no limits set!&#34;
-                   &#34;\n\tTo use the limits for AFG1022, call the class with &#34;
-                   &#34;&#39;override_compatibility=True&#39;&#34;
-                   &#34;\n\tNote that this might lead to unexpected behaviour &#34;
-                   &#34;for custom waveforms and &#39;MIN&#39;/&#39;MAX&#39; keywords.&#34;)
+            msg = (
+                &#34;Model {} not supported, no limits set!&#34;
+                &#34;\n\tTo use the limits for AFG1022, call the class with &#34;
+                &#34;&#39;override_compatibility=True&#39;&#34;
+                &#34;\n\tNote that this might lead to unexpected behaviour &#34;
+                &#34;for custom waveforms and &#39;MIN&#39;/&#39;MAX&#39; keywords.&#34;
+            )
             raise NotCompatibleError(msg)
 
     def write(self, command, custom_err_message=None):
@@ -1686,8 +1879,8 @@ use AFG1022 limits)</dd>
             If status returned by PyVISA write command is not
             `pyvisa.constants.StatusCode.success`
         &#34;&#34;&#34;
-        num_bytes = self.inst.write(command)
-        self.check_pyvisa_status(command, custom_err_message=custom_err_message)
+        num_bytes = self._inst.write(command)
+        self._check_pyvisa_status(command, custom_err_message=custom_err_message)
         return num_bytes
 
     def query(self, command, custom_err_message=None):
@@ -1714,11 +1907,11 @@ use AFG1022 limits)</dd>
             If status returned by PyVISA write command is not
             `pyvisa.constants.StatusCode.success`
         &#34;&#34;&#34;
-        response = self.inst.query(command).strip()
-        self.check_pyvisa_status(command, custom_err_message=custom_err_message)
+        response = self._inst.query(command).strip()
+        self._check_pyvisa_status(command, custom_err_message=custom_err_message)
         return response
 
-    def check_pyvisa_status(self, command, custom_err_message=None):
+    def _check_pyvisa_status(self, command, custom_err_message=None):
         &#34;&#34;&#34;Check the last status code of PyVISA
 
         Parameters
@@ -1737,16 +1930,19 @@ use AFG1022 limits)</dd>
             If status returned by PyVISA write command is not
             `pyvisa.constants.StatusCode.success`
         &#34;&#34;&#34;
-        status = self.inst.last_status
+        status = self._inst.last_status
         if not status == pyvisa.constants.StatusCode.success:
             if custom_err_message is not None:
-                msg = (&#34;Could not {}: pyvisa returned StatusCode {} &#34;
-                       &#34;({})&#34;.format(custom_err_message, status, str(status)))
+                msg = (
+                    f&#34;Could not {custom_err_message}: pyvisa returned &#34;
+                    f&#34;StatusCode {status} ({str(status)})&#34;
+                )
                 raise RuntimeError(msg)
-            else:
-                msg = (&#34;Writing/querying command {} failed: pyvisa returned StatusCode&#34;
-                       &#34; {} ({})&#34;.format(command, status, str(status)))
-                raise RuntimeError(msg)
+            msg = (
+                f&#34;Writing/querying command {command} failed: pyvisa returned &#34;
+                f&#34;StatusCode {status} ({str(status)})&#34;
+            )
+            raise RuntimeError(msg)
         return status
 
     def get_error(self):
@@ -1759,7 +1955,7 @@ use AFG1022 limits)</dd>
         &#34;&#34;&#34;
         return self.query(&#34;SYSTEM:ERROR:NEXT?&#34;)
 
-    def spawn_channel(self, channel, impedance):
+    def _spawn_channel(self, channel, impedance):
         &#34;&#34;&#34;Wrapper function to create a `FuncGenChannel` object for
         a channel -- see the class docstring&#34;&#34;&#34;
         return FuncGenChannel(self, channel, impedance)
@@ -1782,27 +1978,28 @@ use AFG1022 limits)</dd>
         # Find the necessary padding for the table columns
         # by evaluating the maximum length of the entries
         key_padding = max([len(key) for key in settings[0].keys()])
-        ch_paddings = [max([len(str(val[0])) for val in ch_settings.values()])
-                       for ch_settings in settings]
-        padding = [key_padding]+ch_paddings
-        print(&#34;\nCurrent settings for {} {} {}\n&#34;.format(self.maker,
-                                                         self.model,
-                                                         self.serial))
+        ch_paddings = [
+            max([len(str(val[0])) for val in ch_settings.values()])
+            for ch_settings in settings
+        ]
+        padding = [key_padding] + ch_paddings
+        print(f&#34;\nCurrent settings for {self._maker} {self._model} {self._serial}\n&#34;)
         row_format = &#34;{:&gt;{padd[0]}s} {:{padd[1]}s} {:{padd[2]}s} {}&#34;
-        table_header = row_format.format(&#34;Setting&#34;, &#34;Ch1&#34;, &#34;Ch2&#34;,
-                                         &#34;Unit&#34;, padd=padding)
+        table_header = row_format.format(&#34;Setting&#34;, &#34;Ch1&#34;, &#34;Ch2&#34;, &#34;Unit&#34;, padd=padding)
         print(table_header)
-        print(&#34;=&#34;*len(table_header))
-        for (ch1key, (ch1val, unit)), (_, (ch2val, _)) in zip(settings[0].items(),
-                                                              settings[1].items()):
-            print(row_format.format(ch1key, str(ch1val), str(ch2val),
-                                    unit, padd=padding))
+        print(&#34;=&#34; * len(table_header))
+        for (ch1key, (ch1val, unit)), (_, (ch2val, _)) in zip(
+            settings[0].items(), settings[1].items()
+        ):
+            print(
+                row_format.format(ch1key, str(ch1val), str(ch2val), unit, padd=padding)
+            )
 
     def set_settings(self, settings):
         &#34;&#34;&#34;Set the settings of both channels with settings dictionaries
 
         (Each channel is turned off before applying the changes to avoid
-        potenitally harmful combinations)
+        potentially harmful combinations)
 
         Parameteres
         -----------
@@ -1849,23 +2046,26 @@ use AFG1022 limits)</dd>
         &#34;&#34;&#34;
         if self.verbose:
             if state.lower() == &#34;off&#34; and not self.get_frequency_lock():
-                print(&#34;(!) {}: Tried to disable frequency lock, but &#34;
-                      &#34;frequency lock was not enabled&#34;.format(self.model))
+                print(
+                    f&#34;(!) {self._model}: Tried to disable frequency lock, but &#34;
+                    f&#34;frequency lock was not enabled&#34;
+                )
                 return
             if state.lower() == &#34;on&#34; and self.get_frequency_lock():
-                print(&#34;(!) {}: Tried to enable frequency lock, but &#34;
-                      &#34;frequency lock was already enabled&#34;.format(self.model))
+                print(
+                    f&#34;(!) {self._model}: Tried to enable frequency lock, but &#34;
+                    f&#34;frequency lock was already enabled&#34;
+                )
                 return
         # (Sufficient to disable for only one of the channels)
-        cmd = &#34;SOURCE{}:FREQuency:CONCurrent {}&#34;.format(use_channel, state)
-        msg = &#34;turn frequency lock {}&#34;.format(state)
+        cmd = f&#34;SOURCE{use_channel}:FREQuency:CONCurrent {state}&#34;
+        msg = f&#34;turn frequency lock {state}&#34;
         self.write(cmd, custom_err_message=msg)
 
     def software_trig(self):
         &#34;&#34;&#34;NOT TESTED: sends a trigger signal to the device
         (for bursts or modulations)&#34;&#34;&#34;
         self.write(&#34;*TRG&#34;, custom_err_message=&#34;send trigger signal&#34;)
-
 
     ## ~~~~~~~~~~~~~~~~~~~~~ CUSTOM WAVEFORM FUNCTIONS ~~~~~~~~~~~~~~~~~~~~~ ##
 
@@ -1878,7 +2078,7 @@ use AFG1022 limits)</dd>
             Strings with the names of the user functions that are not empty
         &#34;&#34;&#34;
         catalogue = self.query(&#34;DATA:CATalog?&#34;).split(&#34;,&#34;)
-        catalogue = [wf[1:-1] for wf in catalogue] # strip off extra quotes
+        catalogue = [wf[1:-1] for wf in catalogue]  # strip off extra quotes
         return catalogue
 
     def get_custom_waveform(self, memory_num):
@@ -1897,27 +2097,31 @@ use AFG1022 limits)</dd>
         &#34;&#34;&#34;
         # Find the wavefroms in use
         waveforms_in_use = self.get_waveform_catalogue()
-        if &#34;USER{}&#34;.format(memory_num) in waveforms_in_use:
+        if f&#34;USER{memory_num}&#34; in waveforms_in_use:
             # Copy the waveform to edit memory
-            self.write(&#34;DATA:COPY EMEMory,USER{}&#34;.format(memory_num))
+            self.write(f&#34;DATA:COPY EMEMory,USER{memory_num}&#34;)
             # Get the length of the waveform
             waveform_length = int(self.query(&#34;DATA:POINts? EMEMory&#34;))
             # Get the waveform (returns binary values)
-            waveform = self.inst.query_binary_values(&#34;DATA:DATA? EMEMory&#34;,
-                                                     datatype=&#39;H&#39;,
-                                                     is_big_endian=True,
-                                                     container=np.ndarray)
-            msg = (&#34;Waveform length from native length command (DATA:POINts?) &#34;
-                   &#34;and the processed binary values do not match, {} and {} &#34;
-                   &#34;respectively&#34;.format(waveform_length, len(waveform)))
+            waveform = self._inst.query_binary_values(
+                &#34;DATA:DATA? EMEMory&#34;,
+                datatype=&#34;H&#34;,
+                is_big_endian=True,
+                container=np.ndarray,
+            )
+            msg = (
+                f&#34;Waveform length from native length command (DATA:POINts?) &#34;
+                f&#34;and the processed binary values do not match, &#34;
+                f&#34;{waveform_length} and {len(waveform)} respectively&#34;
+            )
             assert len(waveform) == waveform_length, msg
             return waveform
-        else:
-            print(&#34;Waveform USER{} is not in use&#34;.format(memory_num))
-            return np.array([])
+        print(f&#34;Waveform USER{memory_num} is not in use&#34;)
+        return np.array([])
 
-    def set_custom_waveform(self, waveform, normalise=True, memory_num=0,
-                            verify=True, print_progress=True):
+    def set_custom_waveform(
+        self, waveform, normalise=True, memory_num=0, verify=True, print_progress=True
+    ):
         &#34;&#34;&#34;Transfer waveform data to edit memory and then user memory.
         NOTE: Will overwrite without warnings
 
@@ -1951,55 +2155,59 @@ use AFG1022 limits)</dd>
         # Check if waveform data is suitable
         if print_progress:
             print(&#34;Check if waveform data is suitable..&#34;, end=&#34; &#34;)
-        self.check_arb_waveform_length(waveform)
+        self._check_arb_waveform_length(waveform)
         try:
-            self.check_arb_waveform_type_and_range(waveform)
-        except ValueError as e:
+            self._check_arb_waveform_type_and_range(waveform)
+        except ValueError as err:
             if print_progress:
-                print(&#34;\n  &#34;+str(e))
+                print(f&#34;\n  {err}&#34;)
                 print(&#34;Trying again normalising the waveform..&#34;, end=&#34; &#34;)
-            waveform = self.normalise_to_waveform(waveform)
+            waveform = self._normalise_to_waveform(waveform)
         if print_progress:
             print(&#34;ok&#34;)
             print(&#34;Transfer waveform to function generator..&#34;, end=&#34; &#34;)
         # Transfer waveform
-        self.inst.write_binary_values(&#34;DATA:DATA EMEMory,&#34;, waveform,
-                                      datatype=&#39;H&#39;, is_big_endian=True)
-        # The first query after the write_binary_values returns &#39;&#39;,
-        # so here is a mock query
-        self.query(&#34;&#34;)
+        self._inst.write_binary_values(
+            &#34;DATA:DATA EMEMory,&#34;, waveform, datatype=&#34;H&#34;, is_big_endian=True
+        )
+        # Check for errors and check lengths are matching
         transfer_error = self.get_error()
         emem_wf_length = self.query(&#34;DATA:POINts? EMEMory&#34;)
-        if emem_wf_length == &#39;&#39; or not int(emem_wf_length) == len(waveform):
-            msg = (&#34;Waveform in temporary EMEMory has a length of {}, not of &#34;
-                   &#34;the same length as the waveform ({}).\nError from the &#34;
-                   &#34;instrument: {}&#34;.format(emem_wf_length, len(waveform),
-                                           transfer_error))
+        if emem_wf_length == &#34;&#34; or not int(emem_wf_length) == len(waveform):
+            msg = (
+                f&#34;Waveform in temporary EMEMory has a length of {emem_wf_length}&#34;
+                f&#34;, not of the same length as the waveform ({len(waveform)}).&#34;
+                f&#34;\nError from the instrument: {transfer_error}&#34;
+            )
             raise RuntimeError(msg)
         if print_progress:
             print(&#34;ok&#34;)
-            print(&#34;Copy waveform to USER{}..&#34;.format(memory_num), end=&#34; &#34;)
-        self.write(&#34;DATA:COPY USER{},EMEMory&#34;.format(memory_num))
+            print(f&#34;Copy waveform to USER{memory_num}..&#34;, end=&#34; &#34;)
+        self.write(f&#34;DATA:COPY USER{memory_num},EMEMory&#34;)
         if print_progress:
             print(&#34;ok&#34;)
         if verify:
             if print_progress:
-                print(&#34;Verify waveform USER{}..&#34;.format(memory_num))
-            if &#34;USER{}&#34;.format(memory_num) in self.get_waveform_catalogue():
-                self.verify_waveform(waveform, memory_num, normalise=normalise,
-                                     print_result=print_progress)
+                print(f&#34;Verify waveform USER{memory_num}..&#34;)
+            if f&#34;USER{memory_num}&#34; in self.get_waveform_catalogue():
+                self._verify_waveform(
+                    waveform,
+                    memory_num,
+                    normalise=normalise,
+                    print_result=print_progress,
+                )
             else:
-                print(&#34;(!) USER{} is empty&#34;.format(memory_num))
+                print(f&#34;(!) USER{memory_num} is empty&#34;)
         return waveform
 
-    def normalise_to_waveform(self, shape):
+    def _normalise_to_waveform(self, shape):
         &#34;&#34;&#34;Normalise a shape of any discretisation and range to a waveform that
         can be transmitted to the function generator
 
         .. note::
             If you are transferring a flat/constant waveform, do not use this
             normaisation function. Transfer a waveform like
-            `int(self.arbitrary_waveform_resolution/2)*np.ones(2).astype(np.int32)`
+            `int(self._arbitrary_waveform_resolution/2)*np.ones(2).astype(np.int32)`
             without normalising for a well behaved flat function.
 
         Parameters
@@ -2014,15 +2222,14 @@ use AFG1022 limits)</dd>
             Waveform as ints spanning the resolution of the function gen
         &#34;&#34;&#34;
         # Check if waveform data is suitable
-        self.check_arb_waveform_length(shape)
+        self._check_arb_waveform_length(shape)
         # Normalise
         waveform = shape - np.min(shape)
         normalisation_factor = np.max(waveform)
-        waveform = waveform/normalisation_factor*self.arbitrary_waveform_resolution
+        waveform = waveform / normalisation_factor * self._arbitrary_waveform_resolution
         return waveform.astype(np.uint16)
 
-    def verify_waveform(self, waveform, memory_num, normalise=True,
-                        print_result=True):
+    def _verify_waveform(self, waveform, memory_num, normalise=True, print_result=True):
         &#34;&#34;&#34;Compare a waveform in user memory to argument waveform
 
         Parameters
@@ -2044,17 +2251,19 @@ use AFG1022 limits)</dd>
             List of the indices where the waveforms are not equal or `None` if
             the waveforms were of different lengths
         &#34;&#34;&#34;
-        if normalise: # make sure test waveform is normalised
-            waveform = self.normalise_to_waveform(waveform)
+        if normalise:  # make sure test waveform is normalised
+            waveform = self._normalise_to_waveform(waveform)
         # Get the waveform on the instrument
         instrument_waveform = self.get_custom_waveform(memory_num)
         # Compare lengths
         len_inst_wav, len_wav = len(instrument_waveform), len(waveform)
         if not len_inst_wav == len_wav:
             if print_result:
-                print(&#34;The waveform in USER{} and the compared waveform are &#34;
-                      &#34;not of same length (instrument {} vs {})&#34;
-                      &#34;&#34;.format(memory_num, len_inst_wav, len_wav))
+                print(
+                    f&#34;The waveform in USER{memory_num} and the compared &#34;
+                    f&#34;waveform are not of same length (instrument &#34;
+                    f&#34;{len_inst_wav} vs {len_wav})&#34;
+                )
             return False, instrument_waveform, None
         # Compare each element
         not_equal = []
@@ -2062,17 +2271,21 @@ use AFG1022 limits)</dd>
             if not instrument_waveform[i] == waveform[i]:
                 not_equal.append(i)
         # Return depending of whether list is empty or not
-        if not not_equal: # if list is empty
+        if not not_equal:  # if list is empty
             if print_result:
-                print(&#34;The waveform in USER{} and the compared waveform &#34;
-                      &#34;are equal&#34;.format(memory_num))
+                print(
+                    f&#34;The waveform in USER{memory_num} and the compared &#34;
+                    f&#34;waveform are equal&#34;
+                )
             return True, instrument_waveform, not_equal
         if print_result:
-            print(&#34;The waveform in USER{} and the compared waveform are &#34;
-                  &#34;NOT equal&#34;.format(memory_num))
+            print(
+                f&#34;The waveform in USER{memory_num} and the compared &#34;
+                f&#34;waveform are NOT equal&#34;
+            )
         return False, instrument_waveform, not_equal
 
-    def check_arb_waveform_length(self, waveform):
+    def _check_arb_waveform_length(self, waveform):
         &#34;&#34;&#34;Checks if waveform is within the acceptable length
 
         Parameters
@@ -2085,14 +2298,17 @@ use AFG1022 limits)</dd>
         ValueError
             If the waveform is not within the permitted length
         &#34;&#34;&#34;
-        if ((len(waveform) &lt; self.arbitrary_waveform_length[0]) or
-            (len(waveform) &gt; self.arbitrary_waveform_length[1])):
-            msg = (&#34;The waveform is of length {}, which is not within the &#34;
-                   &#34;acceptable length {} &lt; len &lt; {}&#34;
-                   &#34;&#34;.format(len(waveform), *self.arbitrary_waveform_length))
+        if (len(waveform) &lt; self._arbitrary_waveform_length[0]) or (
+            len(waveform) &gt; self._arbitrary_waveform_length[1]
+        ):
+            msg = (
+                &#34;The waveform is of length {}, which is not within the &#34;
+                &#34;acceptable length {} &lt; len &lt; {}&#34;
+                &#34;&#34;.format(len(waveform), *self._arbitrary_waveform_length)
+            )
             raise ValueError(msg)
 
-    def check_arb_waveform_type_and_range(self, waveform):
+    def _check_arb_waveform_type_and_range(self, waveform):
         &#34;&#34;&#34;Checks if waveform is of int/np.int32 type and within the resolution
         of the function generator
 
@@ -2109,182 +2325,85 @@ use AFG1022 limits)</dd>
         &#34;&#34;&#34;
         for value in waveform:
             if not isinstance(value, (int, np.uint16, np.int32)):
-                raise ValueError(&#34;The waveform contains values that are not&#34;
-                                 &#34;int, np.uint16 or np.int32&#34;)
-            if (value &lt; 0) or (value &gt; self.arbitrary_waveform_resolution):
-                raise ValueError(&#34;The waveform contains values out of range &#34;
-                                 &#34;({} is not within the resolution &#34;
-                                 &#34;[0, {}])&#34;.format(value,
-                                        self.arbitrary_waveform_resolution))</code></pre>
+                raise ValueError(
+                    &#34;The waveform contains values that are not&#34;
+                    &#34;int, np.uint16 or np.int32&#34;
+                )
+            if (value &lt; 0) or (value &gt; self._arbitrary_waveform_resolution):
+                raise ValueError(
+                    f&#34;The waveform contains values out of range &#34;
+                    f&#34;({value} is not within the resolution &#34;
+                    f&#34;[0, {self._arbitrary_waveform_resolution}])&#34;
+                )</code></pre>
 </details>
+<h3>Class variables</h3>
+<dl>
+<dt id="tektronix_func_gen.FuncGen.instrument_limits"><code class="name">var <span class="ident">instrument_limits</span></code></dt>
+<dd>
+<div class="desc"><p>dict: Contains the following keys with subdictionaries</p>
+<ul>
+<li><code>frequency lims</code>
+Containing the frequency limits for the instrument where the keys
+"min" and "max" have values corresponding to minimum and maximum
+frequencies in Hz</li>
+<li><code>voltage lims</code>
+Contains the maximum absolute voltage the instrument can output
+for the keys "50ohm" and "highZ" according to the impedance setting</li>
+<li><code>amplitude lims</code>
+Contains the smallest and largest possible amplitudes where the
+keys "50ohm" and "highZ" will have subdictionaries with keys
+"min" and "max"</li>
+</ul></div>
+</dd>
+</dl>
+<h3>Instance variables</h3>
+<dl>
+<dt id="tektronix_func_gen.FuncGen.ch1"><code class="name">var <span class="ident">ch1</span></code></dt>
+<dd>
+<div class="desc"><p><code><a title="tektronix_func_gen.FuncGenChannel" href="#tektronix_func_gen.FuncGenChannel">FuncGenChannel</a></code>: Short hand for <code>channels[0]</code> Object to control channel 1</p></div>
+</dd>
+<dt id="tektronix_func_gen.FuncGen.ch2"><code class="name">var <span class="ident">ch2</span></code></dt>
+<dd>
+<div class="desc"><p><code><a title="tektronix_func_gen.FuncGenChannel" href="#tektronix_func_gen.FuncGenChannel">FuncGenChannel</a></code>: Short hand for <code>channels[1]</code> Object to control channel 2</p></div>
+</dd>
+<dt id="tektronix_func_gen.FuncGen.channels"><code class="name">var <span class="ident">channels</span></code></dt>
+<dd>
+<div class="desc"><p>tuple of <code><a title="tektronix_func_gen.FuncGenChannel" href="#tektronix_func_gen.FuncGenChannel">FuncGenChannel</a></code>: Objects to control the channels</p></div>
+</dd>
+<dt id="tektronix_func_gen.FuncGen.verbose"><code class="name">var <span class="ident">verbose</span></code></dt>
+<dd>
+<div class="desc"><p>bool: Choose whether to print information such as model upon connecting etc</p></div>
+</dd>
+<dt id="tektronix_func_gen.FuncGen.verify_param_set"><code class="name">var <span class="ident">verify_param_set</span></code></dt>
+<dd>
+<div class="desc"><p>bool:
+Verify that a value is successfully set after executing a set function</p></div>
+</dd>
+</dl>
 <h3>Methods</h3>
 <dl>
-<dt id="tektronix_func_gen.FuncGen.check_arb_waveform_length"><code class="name flex">
-<span>def <span class="ident">check_arb_waveform_length</span></span>(<span>self, waveform)</span>
-</code></dt>
-<dd>
-<section class="desc"><p>Checks if waveform is within the acceptable length</p>
-<h2 id="parameters">Parameters</h2>
-<dl>
-<dt><strong><code>waveform</code></strong> :&ensp;<code>array_like</code></dt>
-<dd>Waveform or voltage list to be checked</dd>
-</dl>
-<h2 id="raises">Raises</h2>
-<dl>
-<dt><code>ValueError</code></dt>
-<dd>If the waveform is not within the permitted length</dd>
-</dl></section>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def check_arb_waveform_length(self, waveform):
-    &#34;&#34;&#34;Checks if waveform is within the acceptable length
-
-    Parameters
-    ----------
-    waveform : array_like
-        Waveform or voltage list to be checked
-
-    Raises
-    ------
-    ValueError
-        If the waveform is not within the permitted length
-    &#34;&#34;&#34;
-    if ((len(waveform) &lt; self.arbitrary_waveform_length[0]) or
-        (len(waveform) &gt; self.arbitrary_waveform_length[1])):
-        msg = (&#34;The waveform is of length {}, which is not within the &#34;
-               &#34;acceptable length {} &lt; len &lt; {}&#34;
-               &#34;&#34;.format(len(waveform), *self.arbitrary_waveform_length))
-        raise ValueError(msg)</code></pre>
-</details>
-</dd>
-<dt id="tektronix_func_gen.FuncGen.check_arb_waveform_type_and_range"><code class="name flex">
-<span>def <span class="ident">check_arb_waveform_type_and_range</span></span>(<span>self, waveform)</span>
-</code></dt>
-<dd>
-<section class="desc"><p>Checks if waveform is of int/np.int32 type and within the resolution
-of the function generator</p>
-<h2 id="parameters">Parameters</h2>
-<dl>
-<dt><strong><code>waveform</code></strong> :&ensp;<code>array_like</code></dt>
-<dd>Waveform or voltage list to be checked</dd>
-</dl>
-<h2 id="raises">Raises</h2>
-<dl>
-<dt><code>ValueError</code></dt>
-<dd>If the waveform values are not int, np.uint16 or np.int32, or the
-values are not within the permitted range</dd>
-</dl></section>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def check_arb_waveform_type_and_range(self, waveform):
-    &#34;&#34;&#34;Checks if waveform is of int/np.int32 type and within the resolution
-    of the function generator
-
-    Parameters
-    ----------
-    waveform : array_like
-        Waveform or voltage list to be checked
-
-    Raises
-    ------
-    ValueError
-        If the waveform values are not int, np.uint16 or np.int32, or the
-        values are not within the permitted range
-    &#34;&#34;&#34;
-    for value in waveform:
-        if not isinstance(value, (int, np.uint16, np.int32)):
-            raise ValueError(&#34;The waveform contains values that are not&#34;
-                             &#34;int, np.uint16 or np.int32&#34;)
-        if (value &lt; 0) or (value &gt; self.arbitrary_waveform_resolution):
-            raise ValueError(&#34;The waveform contains values out of range &#34;
-                             &#34;({} is not within the resolution &#34;
-                             &#34;[0, {}])&#34;.format(value,
-                                    self.arbitrary_waveform_resolution))</code></pre>
-</details>
-</dd>
-<dt id="tektronix_func_gen.FuncGen.check_pyvisa_status"><code class="name flex">
-<span>def <span class="ident">check_pyvisa_status</span></span>(<span>self, command, custom_err_message=None)</span>
-</code></dt>
-<dd>
-<section class="desc"><p>Check the last status code of PyVISA</p>
-<h2 id="parameters">Parameters</h2>
-<dl>
-<dt><strong><code>command</code></strong> :&ensp;<code>str</code></dt>
-<dd>The VISA write/query command</dd>
-</dl>
-<h2 id="returns">Returns</h2>
-<dl>
-<dt><strong><code>status</code></strong> :&ensp;<code>pyvisa.constants.StatusCode</code></dt>
-<dd>Return value of the library call</dd>
-</dl>
-<h2 id="raises">Raises</h2>
-<dl>
-<dt><code>RuntimeError</code></dt>
-<dd>If status returned by PyVISA write command is not
-<code>pyvisa.constants.StatusCode.success</code></dd>
-</dl></section>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def check_pyvisa_status(self, command, custom_err_message=None):
-    &#34;&#34;&#34;Check the last status code of PyVISA
-
-    Parameters
-    ----------
-    command : str
-        The VISA write/query command
-
-    Returns
-    -------
-    status : pyvisa.constants.StatusCode
-        Return value of the library call
-
-    Raises
-    ------
-    RuntimeError
-        If status returned by PyVISA write command is not
-        `pyvisa.constants.StatusCode.success`
-    &#34;&#34;&#34;
-    status = self.inst.last_status
-    if not status == pyvisa.constants.StatusCode.success:
-        if custom_err_message is not None:
-            msg = (&#34;Could not {}: pyvisa returned StatusCode {} &#34;
-                   &#34;({})&#34;.format(custom_err_message, status, str(status)))
-            raise RuntimeError(msg)
-        else:
-            msg = (&#34;Writing/querying command {} failed: pyvisa returned StatusCode&#34;
-                   &#34; {} ({})&#34;.format(command, status, str(status)))
-            raise RuntimeError(msg)
-    return status</code></pre>
-</details>
-</dd>
 <dt id="tektronix_func_gen.FuncGen.close"><code class="name flex">
 <span>def <span class="ident">close</span></span>(<span>self)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Close the connection to the instrument</p></section>
+<div class="desc"><p>Close the connection to the instrument</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">def close(self):
     &#34;&#34;&#34;Close the connection to the instrument&#34;&#34;&#34;
-    self.inst.close()</code></pre>
+    self._inst.close()</code></pre>
 </details>
 </dd>
 <dt id="tektronix_func_gen.FuncGen.get_custom_waveform"><code class="name flex">
 <span>def <span class="ident">get_custom_waveform</span></span>(<span>self, memory_num)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Get the waveform currently stored in USER<memory_num></p>
+<div class="desc"><p>Get the waveform currently stored in USER<memory_num></p>
 <h2 id="parameters">Parameters</h2>
 <dl>
-<dt><strong><code>memory_num</code></strong> :&ensp;<code>str</code> or <code>int</code> {<code>0</code>,<code>...</code>,<code>255</code>}, default <code>0</code></dt>
+<dt><strong><code>memory_num</code></strong> :&ensp;<code>str</code> or <code>int {0,...,255}</code>, default <code>0</code></dt>
 <dd>Select which user memory to compare with</dd>
 </dl>
 <h2 id="returns">Returns</h2>
@@ -2292,7 +2411,7 @@ values are not within the permitted range</dd>
 <dt><strong><code>waveform</code></strong> :&ensp;<code>ndarray</code></dt>
 <dd>Waveform as ints spanning the resolution of the function gen or
 and empty array if waveform not in use</dd>
-</dl></section>
+</dl></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -2313,36 +2432,39 @@ and empty array if waveform not in use</dd>
     &#34;&#34;&#34;
     # Find the wavefroms in use
     waveforms_in_use = self.get_waveform_catalogue()
-    if &#34;USER{}&#34;.format(memory_num) in waveforms_in_use:
+    if f&#34;USER{memory_num}&#34; in waveforms_in_use:
         # Copy the waveform to edit memory
-        self.write(&#34;DATA:COPY EMEMory,USER{}&#34;.format(memory_num))
+        self.write(f&#34;DATA:COPY EMEMory,USER{memory_num}&#34;)
         # Get the length of the waveform
         waveform_length = int(self.query(&#34;DATA:POINts? EMEMory&#34;))
         # Get the waveform (returns binary values)
-        waveform = self.inst.query_binary_values(&#34;DATA:DATA? EMEMory&#34;,
-                                                 datatype=&#39;H&#39;,
-                                                 is_big_endian=True,
-                                                 container=np.ndarray)
-        msg = (&#34;Waveform length from native length command (DATA:POINts?) &#34;
-               &#34;and the processed binary values do not match, {} and {} &#34;
-               &#34;respectively&#34;.format(waveform_length, len(waveform)))
+        waveform = self._inst.query_binary_values(
+            &#34;DATA:DATA? EMEMory&#34;,
+            datatype=&#34;H&#34;,
+            is_big_endian=True,
+            container=np.ndarray,
+        )
+        msg = (
+            f&#34;Waveform length from native length command (DATA:POINts?) &#34;
+            f&#34;and the processed binary values do not match, &#34;
+            f&#34;{waveform_length} and {len(waveform)} respectively&#34;
+        )
         assert len(waveform) == waveform_length, msg
         return waveform
-    else:
-        print(&#34;Waveform USER{} is not in use&#34;.format(memory_num))
-        return np.array([])</code></pre>
+    print(f&#34;Waveform USER{memory_num} is not in use&#34;)
+    return np.array([])</code></pre>
 </details>
 </dd>
 <dt id="tektronix_func_gen.FuncGen.get_error"><code class="name flex">
 <span>def <span class="ident">get_error</span></span>(<span>self)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Get the contents of the Error/Event queue on the device</p>
+<div class="desc"><p>Get the contents of the Error/Event queue on the device</p>
 <h2 id="returns">Returns</h2>
 <dl>
 <dt><code>str</code></dt>
 <dd>Error/event number, description of error/event</dd>
-</dl></section>
+</dl></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -2362,12 +2484,12 @@ and empty array if waveform not in use</dd>
 <span>def <span class="ident">get_frequency_lock</span></span>(<span>self)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Check if frequency lock is enabled</p>
+<div class="desc"><p>Check if frequency lock is enabled</p>
 <h2 id="returns">Returns</h2>
 <dl>
 <dt><code>bool</code></dt>
 <dd><code>True</code> if frequency lock enabled</dd>
-</dl></section>
+</dl></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -2388,14 +2510,14 @@ and empty array if waveform not in use</dd>
 <span>def <span class="ident">get_settings</span></span>(<span>self)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Get dictionaries of the current settings of the two channels</p>
+<div class="desc"><p>Get dictionaries of the current settings of the two channels</p>
 <h2 id="returns">Returns</h2>
 <dl>
 <dt><strong><code>settings</code></strong> :&ensp;<code>list</code> of <code>dicts</code></dt>
 <dd>[ch1_dict, ch2_dict]: Settings currently in use as a dictionary
 with keys output, function, amplitude, offset, and frequency with
 corresponding values</dd>
-</dl></section>
+</dl></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -2417,12 +2539,12 @@ corresponding values</dd>
 <span>def <span class="ident">get_waveform_catalogue</span></span>(<span>self)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Get list of the waveforms that are in use (not empty)</p>
+<div class="desc"><p>Get list of the waveforms that are in use (not empty)</p>
 <h2 id="returns">Returns</h2>
 <dl>
 <dt><strong><code>catalogue</code></strong> :&ensp;<code>list</code></dt>
 <dd>Strings with the names of the user functions that are not empty</dd>
-</dl></section>
+</dl></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -2436,117 +2558,15 @@ corresponding values</dd>
         Strings with the names of the user functions that are not empty
     &#34;&#34;&#34;
     catalogue = self.query(&#34;DATA:CATalog?&#34;).split(&#34;,&#34;)
-    catalogue = [wf[1:-1] for wf in catalogue] # strip off extra quotes
+    catalogue = [wf[1:-1] for wf in catalogue]  # strip off extra quotes
     return catalogue</code></pre>
-</details>
-</dd>
-<dt id="tektronix_func_gen.FuncGen.initialise_model_properties"><code class="name flex">
-<span>def <span class="ident">initialise_model_properties</span></span>(<span>self)</span>
-</code></dt>
-<dd>
-<section class="desc"><p>Initialises the limits of what the instrument can handle according
-to the instrument model</p>
-<h2 id="raises">Raises</h2>
-<dl>
-<dt><a title="tektronix_func_gen.NotCompatibleError" href="#tektronix_func_gen.NotCompatibleError"><code>NotCompatibleError</code></a></dt>
-<dd>If the connected model is not necessarily compatible with this
-package, slimits are not known.</dd>
-</dl></section>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def initialise_model_properties(self):
-    &#34;&#34;&#34;Initialises the limits of what the instrument can handle according
-    to the instrument model
-
-    Raises
-    ------
-    NotCompatibleError
-        If the connected model is not necessarily compatible with this
-        package, slimits are not known.
-    &#34;&#34;&#34;
-    if self.model == &#39;AFG1022&#39; or self.override_compatibility:
-        self.instrument_limits = {
-            &#34;frequency lims&#34;: ({&#34;min&#34;: 1e-6, &#34;max&#34;: 25e6}, &#34;Hz&#34;),
-            &#34;voltage lims&#34;:   ({&#34;50ohm&#34;: {&#34;min&#34;: -5, &#34;max&#34;: 5},
-                                &#34;highZ&#34;: {&#34;min&#34;: -10, &#34;max&#34;: 10}}, &#34;V&#34;),
-            &#34;amplitude lims&#34;: ({&#34;50ohm&#34;: {&#34;min&#34;: 0.001, &#34;max&#34;: 10},
-                                &#34;highZ&#34;: {&#34;min&#34;: 0.002, &#34;max&#34;: 20}}, &#34;Vpp&#34;)}
-        self.arbitrary_waveform_length = [2, 8192]  # min length, max length
-        self.arbitrary_waveform_resolution = 16383  # 14 bit
-    else:
-        msg = (&#34;Model {} not supported, no limits set!&#34;
-               &#34;\n\tTo use the limits for AFG1022, call the class with &#34;
-               &#34;&#39;override_compatibility=True&#39;&#34;
-               &#34;\n\tNote that this might lead to unexpected behaviour &#34;
-               &#34;for custom waveforms and &#39;MIN&#39;/&#39;MAX&#39; keywords.&#34;)
-        raise NotCompatibleError(msg)</code></pre>
-</details>
-</dd>
-<dt id="tektronix_func_gen.FuncGen.normalise_to_waveform"><code class="name flex">
-<span>def <span class="ident">normalise_to_waveform</span></span>(<span>self, shape)</span>
-</code></dt>
-<dd>
-<section class="desc"><p>Normalise a shape of any discretisation and range to a waveform that
-can be transmitted to the function generator</p>
-<div class="admonition note">
-<p class="admonition-title">Note</p>
-<p>If you are transferring a flat/constant waveform, do not use this
-normaisation function. Transfer a waveform like
-<code>int(self.arbitrary_waveform_resolution/2)*np.ones(2).astype(np.int32)</code>
-without normalising for a well behaved flat function.</p>
-</div>
-<h2 id="parameters">Parameters</h2>
-<dl>
-<dt><strong><code>shape</code></strong> :&ensp;<code>array_like</code></dt>
-<dd>Array to be transformed to waveform, can be ints or floats,
-any normalisation or discretisation</dd>
-</dl>
-<h2 id="returns">Returns</h2>
-<dl>
-<dt><strong><code>waveform</code></strong> :&ensp;<code>ndarray</code></dt>
-<dd>Waveform as ints spanning the resolution of the function gen</dd>
-</dl></section>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def normalise_to_waveform(self, shape):
-    &#34;&#34;&#34;Normalise a shape of any discretisation and range to a waveform that
-    can be transmitted to the function generator
-
-    .. note::
-        If you are transferring a flat/constant waveform, do not use this
-        normaisation function. Transfer a waveform like
-        `int(self.arbitrary_waveform_resolution/2)*np.ones(2).astype(np.int32)`
-        without normalising for a well behaved flat function.
-
-    Parameters
-    ----------
-    shape : array_like
-        Array to be transformed to waveform, can be ints or floats,
-        any normalisation or discretisation
-
-    Returns
-    -------
-    waveform : ndarray
-        Waveform as ints spanning the resolution of the function gen
-    &#34;&#34;&#34;
-    # Check if waveform data is suitable
-    self.check_arb_waveform_length(shape)
-    # Normalise
-    waveform = shape - np.min(shape)
-    normalisation_factor = np.max(waveform)
-    waveform = waveform/normalisation_factor*self.arbitrary_waveform_resolution
-    return waveform.astype(np.uint16)</code></pre>
 </details>
 </dd>
 <dt id="tektronix_func_gen.FuncGen.print_settings"><code class="name flex">
 <span>def <span class="ident">print_settings</span></span>(<span>self)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Prints table of the current setting for both channels</p></section>
+<div class="desc"><p>Prints table of the current setting for both channels</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -2557,28 +2577,29 @@ any normalisation or discretisation</dd>
     # Find the necessary padding for the table columns
     # by evaluating the maximum length of the entries
     key_padding = max([len(key) for key in settings[0].keys()])
-    ch_paddings = [max([len(str(val[0])) for val in ch_settings.values()])
-                   for ch_settings in settings]
-    padding = [key_padding]+ch_paddings
-    print(&#34;\nCurrent settings for {} {} {}\n&#34;.format(self.maker,
-                                                     self.model,
-                                                     self.serial))
+    ch_paddings = [
+        max([len(str(val[0])) for val in ch_settings.values()])
+        for ch_settings in settings
+    ]
+    padding = [key_padding] + ch_paddings
+    print(f&#34;\nCurrent settings for {self._maker} {self._model} {self._serial}\n&#34;)
     row_format = &#34;{:&gt;{padd[0]}s} {:{padd[1]}s} {:{padd[2]}s} {}&#34;
-    table_header = row_format.format(&#34;Setting&#34;, &#34;Ch1&#34;, &#34;Ch2&#34;,
-                                     &#34;Unit&#34;, padd=padding)
+    table_header = row_format.format(&#34;Setting&#34;, &#34;Ch1&#34;, &#34;Ch2&#34;, &#34;Unit&#34;, padd=padding)
     print(table_header)
-    print(&#34;=&#34;*len(table_header))
-    for (ch1key, (ch1val, unit)), (_, (ch2val, _)) in zip(settings[0].items(),
-                                                          settings[1].items()):
-        print(row_format.format(ch1key, str(ch1val), str(ch2val),
-                                unit, padd=padding))</code></pre>
+    print(&#34;=&#34; * len(table_header))
+    for (ch1key, (ch1val, unit)), (_, (ch2val, _)) in zip(
+        settings[0].items(), settings[1].items()
+    ):
+        print(
+            row_format.format(ch1key, str(ch1val), str(ch2val), unit, padd=padding)
+        )</code></pre>
 </details>
 </dd>
 <dt id="tektronix_func_gen.FuncGen.query"><code class="name flex">
 <span>def <span class="ident">query</span></span>(<span>self, command, custom_err_message=None)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Query the instrument</p>
+<div class="desc"><p>Query the instrument</p>
 <h2 id="parameters">Parameters</h2>
 <dl>
 <dt><strong><code>command</code></strong> :&ensp;<code>str</code></dt>
@@ -2599,7 +2620,7 @@ pyvisa returned StatusCode .."</dd>
 <dt><code>RuntimeError</code></dt>
 <dd>If status returned by PyVISA write command is not
 <code>pyvisa.constants.StatusCode.success</code></dd>
-</dl></section>
+</dl></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -2628,8 +2649,8 @@ pyvisa returned StatusCode .."</dd>
         If status returned by PyVISA write command is not
         `pyvisa.constants.StatusCode.success`
     &#34;&#34;&#34;
-    response = self.inst.query(command).strip()
-    self.check_pyvisa_status(command, custom_err_message=custom_err_message)
+    response = self._inst.query(command).strip()
+    self._check_pyvisa_status(command, custom_err_message=custom_err_message)
     return response</code></pre>
 </details>
 </dd>
@@ -2637,7 +2658,7 @@ pyvisa returned StatusCode .."</dd>
 <span>def <span class="ident">set_custom_waveform</span></span>(<span>self, waveform, normalise=True, memory_num=0, verify=True, print_progress=True)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Transfer waveform data to edit memory and then user memory.
+<div class="desc"><p>Transfer waveform data to edit memory and then user memory.
 NOTE: Will overwrite without warnings</p>
 <h2 id="parameters">Parameters</h2>
 <dl>
@@ -2647,7 +2668,7 @@ or ints spanning the resolution of the function generator</dd>
 <dt><strong><code>normalise</code></strong> :&ensp;<code>bool</code></dt>
 <dd>Choose whether to normalise the waveform to ints over the
 resolution span of the function generator</dd>
-<dt><strong><code>memory_num</code></strong> :&ensp;<code>str</code> or <code>int</code> {<code>0</code>,<code>...</code>,<code>255</code>}, default <code>0</code></dt>
+<dt><strong><code>memory_num</code></strong> :&ensp;<code>str</code> or <code>int {0,...,255}</code>, default <code>0</code></dt>
 <dd>Select which user memory to copy to</dd>
 <dt><strong><code>verify</code></strong> :&ensp;<code>bool</code>, default <code>True</code></dt>
 <dd>Verify that the waveform has been transferred and is what was sent</dd>
@@ -2666,13 +2687,14 @@ resolution span of the function generator</dd>
 <dt><code>RuntimeError</code></dt>
 <dd>If the waveform transferred to the instrument is of a different
 length than the waveform supplied</dd>
-</dl></section>
+</dl></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def set_custom_waveform(self, waveform, normalise=True, memory_num=0,
-                        verify=True, print_progress=True):
+<pre><code class="python">def set_custom_waveform(
+    self, waveform, normalise=True, memory_num=0, verify=True, print_progress=True
+):
     &#34;&#34;&#34;Transfer waveform data to edit memory and then user memory.
     NOTE: Will overwrite without warnings
 
@@ -2706,45 +2728,49 @@ length than the waveform supplied</dd>
     # Check if waveform data is suitable
     if print_progress:
         print(&#34;Check if waveform data is suitable..&#34;, end=&#34; &#34;)
-    self.check_arb_waveform_length(waveform)
+    self._check_arb_waveform_length(waveform)
     try:
-        self.check_arb_waveform_type_and_range(waveform)
-    except ValueError as e:
+        self._check_arb_waveform_type_and_range(waveform)
+    except ValueError as err:
         if print_progress:
-            print(&#34;\n  &#34;+str(e))
+            print(f&#34;\n  {err}&#34;)
             print(&#34;Trying again normalising the waveform..&#34;, end=&#34; &#34;)
-        waveform = self.normalise_to_waveform(waveform)
+        waveform = self._normalise_to_waveform(waveform)
     if print_progress:
         print(&#34;ok&#34;)
         print(&#34;Transfer waveform to function generator..&#34;, end=&#34; &#34;)
     # Transfer waveform
-    self.inst.write_binary_values(&#34;DATA:DATA EMEMory,&#34;, waveform,
-                                  datatype=&#39;H&#39;, is_big_endian=True)
-    # The first query after the write_binary_values returns &#39;&#39;,
-    # so here is a mock query
-    self.query(&#34;&#34;)
+    self._inst.write_binary_values(
+        &#34;DATA:DATA EMEMory,&#34;, waveform, datatype=&#34;H&#34;, is_big_endian=True
+    )
+    # Check for errors and check lengths are matching
     transfer_error = self.get_error()
     emem_wf_length = self.query(&#34;DATA:POINts? EMEMory&#34;)
-    if emem_wf_length == &#39;&#39; or not int(emem_wf_length) == len(waveform):
-        msg = (&#34;Waveform in temporary EMEMory has a length of {}, not of &#34;
-               &#34;the same length as the waveform ({}).\nError from the &#34;
-               &#34;instrument: {}&#34;.format(emem_wf_length, len(waveform),
-                                       transfer_error))
+    if emem_wf_length == &#34;&#34; or not int(emem_wf_length) == len(waveform):
+        msg = (
+            f&#34;Waveform in temporary EMEMory has a length of {emem_wf_length}&#34;
+            f&#34;, not of the same length as the waveform ({len(waveform)}).&#34;
+            f&#34;\nError from the instrument: {transfer_error}&#34;
+        )
         raise RuntimeError(msg)
     if print_progress:
         print(&#34;ok&#34;)
-        print(&#34;Copy waveform to USER{}..&#34;.format(memory_num), end=&#34; &#34;)
-    self.write(&#34;DATA:COPY USER{},EMEMory&#34;.format(memory_num))
+        print(f&#34;Copy waveform to USER{memory_num}..&#34;, end=&#34; &#34;)
+    self.write(f&#34;DATA:COPY USER{memory_num},EMEMory&#34;)
     if print_progress:
         print(&#34;ok&#34;)
     if verify:
         if print_progress:
-            print(&#34;Verify waveform USER{}..&#34;.format(memory_num))
-        if &#34;USER{}&#34;.format(memory_num) in self.get_waveform_catalogue():
-            self.verify_waveform(waveform, memory_num, normalise=normalise,
-                                 print_result=print_progress)
+            print(f&#34;Verify waveform USER{memory_num}..&#34;)
+        if f&#34;USER{memory_num}&#34; in self.get_waveform_catalogue():
+            self._verify_waveform(
+                waveform,
+                memory_num,
+                normalise=normalise,
+                print_result=print_progress,
+            )
         else:
-            print(&#34;(!) USER{} is empty&#34;.format(memory_num))
+            print(f&#34;(!) USER{memory_num} is empty&#34;)
     return waveform</code></pre>
 </details>
 </dd>
@@ -2752,17 +2778,17 @@ length than the waveform supplied</dd>
 <span>def <span class="ident">set_frequency_lock</span></span>(<span>self, state, use_channel=1)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Enable the frequency lock to make the two channels have the same
+<div class="desc"><p>Enable the frequency lock to make the two channels have the same
 frequency and phase of their signals, also after adjustments.</p>
-<p>See also <a title="tektronix_func_gen.FuncGen.syncronise_waveforms" href="#tektronix_func_gen.FuncGen.syncronise_waveforms"><code>FuncGen.syncronise_waveforms()</code></a> for one-time sync only.</p>
+<p>See also <code><a title="tektronix_func_gen.FuncGen.syncronise_waveforms" href="#tektronix_func_gen.FuncGen.syncronise_waveforms">FuncGen.syncronise_waveforms()</a></code> for one-time sync only.</p>
 <h2 id="parameters">Parameters</h2>
 <dl>
-<dt><strong><code>state</code></strong> :&ensp;{<code>"ON"</code>, <code>"OFF"</code>}</dt>
+<dt><strong><code>state</code></strong> :&ensp;<code>{"ON", "OFF"}</code></dt>
 <dd>ON to enable, OFF to disable the lock</dd>
 <dt><strong><code>use_channel</code></strong> :&ensp;<code>int</code>, default <code>1</code></dt>
 <dd>Only relevant if turning the lock ON: The channel whose frequency
 shall be used as the common freqency</dd>
-</dl></section>
+</dl></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -2783,16 +2809,20 @@ shall be used as the common freqency</dd>
     &#34;&#34;&#34;
     if self.verbose:
         if state.lower() == &#34;off&#34; and not self.get_frequency_lock():
-            print(&#34;(!) {}: Tried to disable frequency lock, but &#34;
-                  &#34;frequency lock was not enabled&#34;.format(self.model))
+            print(
+                f&#34;(!) {self._model}: Tried to disable frequency lock, but &#34;
+                f&#34;frequency lock was not enabled&#34;
+            )
             return
         if state.lower() == &#34;on&#34; and self.get_frequency_lock():
-            print(&#34;(!) {}: Tried to enable frequency lock, but &#34;
-                  &#34;frequency lock was already enabled&#34;.format(self.model))
+            print(
+                f&#34;(!) {self._model}: Tried to enable frequency lock, but &#34;
+                f&#34;frequency lock was already enabled&#34;
+            )
             return
     # (Sufficient to disable for only one of the channels)
-    cmd = &#34;SOURCE{}:FREQuency:CONCurrent {}&#34;.format(use_channel, state)
-    msg = &#34;turn frequency lock {}&#34;.format(state)
+    cmd = f&#34;SOURCE{use_channel}:FREQuency:CONCurrent {state}&#34;
+    msg = f&#34;turn frequency lock {state}&#34;
     self.write(cmd, custom_err_message=msg)</code></pre>
 </details>
 </dd>
@@ -2800,16 +2830,14 @@ shall be used as the common freqency</dd>
 <span>def <span class="ident">set_settings</span></span>(<span>self, settings)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Set the settings of both channels with settings dictionaries</p>
+<div class="desc"><p>Set the settings of both channels with settings dictionaries</p>
 <p>(Each channel is turned off before applying the changes to avoid
-potenitally harmful combinations)</p>
+potentially harmful combinations)</p>
 <h2 id="parameteres">Parameteres</h2>
-<dl>
-<dt><strong><code>settings</code></strong> :&ensp;<code>list</code> of <code>dicts</code></dt>
-<dd>List of settings dictionaries as returned by <code>get_settings</code>, first
+<p>settings : list of dicts
+List of settings dictionaries as returned by <code>get_settings</code>, first
 entry for channel 1, second for channel 2. The dictionaries should
-have keys output, function, amplitude, offset, and frequency</dd>
-</dl></section>
+have keys output, function, amplitude, offset, and frequency</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -2818,7 +2846,7 @@ have keys output, function, amplitude, offset, and frequency</dd>
     &#34;&#34;&#34;Set the settings of both channels with settings dictionaries
 
     (Each channel is turned off before applying the changes to avoid
-    potenitally harmful combinations)
+    potentially harmful combinations)
 
     Parameteres
     -----------
@@ -2835,8 +2863,8 @@ have keys output, function, amplitude, offset, and frequency</dd>
 <span>def <span class="ident">software_trig</span></span>(<span>self)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>NOT TESTED: sends a trigger signal to the device
-(for bursts or modulations)</p></section>
+<div class="desc"><p>NOT TESTED: sends a trigger signal to the device
+(for bursts or modulations)</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -2847,29 +2875,13 @@ have keys output, function, amplitude, offset, and frequency</dd>
     self.write(&#34;*TRG&#34;, custom_err_message=&#34;send trigger signal&#34;)</code></pre>
 </details>
 </dd>
-<dt id="tektronix_func_gen.FuncGen.spawn_channel"><code class="name flex">
-<span>def <span class="ident">spawn_channel</span></span>(<span>self, channel, impedance)</span>
-</code></dt>
-<dd>
-<section class="desc"><p>Wrapper function to create a <a title="tektronix_func_gen.FuncGenChannel" href="#tektronix_func_gen.FuncGenChannel"><code>FuncGenChannel</code></a> object for
-a channel &ndash; see the class docstring</p></section>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def spawn_channel(self, channel, impedance):
-    &#34;&#34;&#34;Wrapper function to create a `FuncGenChannel` object for
-    a channel -- see the class docstring&#34;&#34;&#34;
-    return FuncGenChannel(self, channel, impedance)</code></pre>
-</details>
-</dd>
 <dt id="tektronix_func_gen.FuncGen.syncronise_waveforms"><code class="name flex">
 <span>def <span class="ident">syncronise_waveforms</span></span>(<span>self)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Syncronise waveforms of the two channels when using the same frequency</p>
+<div class="desc"><p>Syncronise waveforms of the two channels when using the same frequency</p>
 <p>Note: Does NOT enable the frequency lock that can be enabled on the
-user interface of the instrument)</p></section>
+user interface of the instrument)</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -2883,91 +2895,11 @@ user interface of the instrument)</p></section>
     self.write(&#34;:PHAS:INIT&#34;, custom_err_message=&#34;syncronise waveforms&#34;)</code></pre>
 </details>
 </dd>
-<dt id="tektronix_func_gen.FuncGen.verify_waveform"><code class="name flex">
-<span>def <span class="ident">verify_waveform</span></span>(<span>self, waveform, memory_num, normalise=True, print_result=True)</span>
-</code></dt>
-<dd>
-<section class="desc"><p>Compare a waveform in user memory to argument waveform</p>
-<h2 id="parameters">Parameters</h2>
-<dl>
-<dt><strong><code>waveform</code></strong> :&ensp;<code>ndarray</code></dt>
-<dd>Waveform as ints spanning the resolution of the function gen</dd>
-<dt><strong><code>memory_num</code></strong> :&ensp;<code>str</code> or <code>int</code> {<code>0</code>,<code>...</code>,<code>255</code>}, default <code>0</code></dt>
-<dd>Select which user memory to compare with</dd>
-<dt><strong><code>normalise</code></strong> :&ensp;<code>bool</code>, default <code>True</code></dt>
-<dd>Normalise test waveform</dd>
-</dl>
-<h2 id="returns">Returns</h2>
-<dl>
-<dt><code>bool</code></dt>
-<dd>Boolean according to equal/not equal</dd>
-<dt><code>instrument_waveform</code></dt>
-<dd>The waveform on the instrument</dd>
-</dl>
-<p>list or <code>None</code>
-List of the indices where the waveforms are not equal or <code>None</code> if
-the waveforms were of different lengths</p></section>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def verify_waveform(self, waveform, memory_num, normalise=True,
-                    print_result=True):
-    &#34;&#34;&#34;Compare a waveform in user memory to argument waveform
-
-    Parameters
-    ----------
-    waveform : ndarray
-        Waveform as ints spanning the resolution of the function gen
-    memory_num : str or int {0,...,255}, default 0
-        Select which user memory to compare with
-    normalise : bool, default `True`
-        Normalise test waveform
-
-    Returns
-    -------
-    bool
-        Boolean according to equal/not equal
-    instrument_waveform
-        The waveform on the instrument
-    list or `None`
-        List of the indices where the waveforms are not equal or `None` if
-        the waveforms were of different lengths
-    &#34;&#34;&#34;
-    if normalise: # make sure test waveform is normalised
-        waveform = self.normalise_to_waveform(waveform)
-    # Get the waveform on the instrument
-    instrument_waveform = self.get_custom_waveform(memory_num)
-    # Compare lengths
-    len_inst_wav, len_wav = len(instrument_waveform), len(waveform)
-    if not len_inst_wav == len_wav:
-        if print_result:
-            print(&#34;The waveform in USER{} and the compared waveform are &#34;
-                  &#34;not of same length (instrument {} vs {})&#34;
-                  &#34;&#34;.format(memory_num, len_inst_wav, len_wav))
-        return False, instrument_waveform, None
-    # Compare each element
-    not_equal = []
-    for i in range(len_wav):
-        if not instrument_waveform[i] == waveform[i]:
-            not_equal.append(i)
-    # Return depending of whether list is empty or not
-    if not not_equal: # if list is empty
-        if print_result:
-            print(&#34;The waveform in USER{} and the compared waveform &#34;
-                  &#34;are equal&#34;.format(memory_num))
-        return True, instrument_waveform, not_equal
-    if print_result:
-        print(&#34;The waveform in USER{} and the compared waveform are &#34;
-              &#34;NOT equal&#34;.format(memory_num))
-    return False, instrument_waveform, not_equal</code></pre>
-</details>
-</dd>
 <dt id="tektronix_func_gen.FuncGen.write"><code class="name flex">
 <span>def <span class="ident">write</span></span>(<span>self, command, custom_err_message=None)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Write a VISA command to the instrument</p>
+<div class="desc"><p>Write a VISA command to the instrument</p>
 <h2 id="parameters">Parameters</h2>
 <dl>
 <dt><strong><code>command</code></strong> :&ensp;<code>str</code></dt>
@@ -2988,7 +2920,7 @@ pyvisa returned StatusCode .."</dd>
 <dt><code>RuntimeError</code></dt>
 <dd>If status returned by PyVISA write command is not
 <code>pyvisa.constants.StatusCode.success</code></dd>
-</dl></section>
+</dl></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -3017,8 +2949,8 @@ pyvisa returned StatusCode .."</dd>
         If status returned by PyVISA write command is not
         `pyvisa.constants.StatusCode.success`
     &#34;&#34;&#34;
-    num_bytes = self.inst.write(command)
-    self.check_pyvisa_status(command, custom_err_message=custom_err_message)
+    num_bytes = self._inst.write(command)
+    self._check_pyvisa_status(command, custom_err_message=custom_err_message)
     return num_bytes</code></pre>
 </details>
 </dd>
@@ -3029,33 +2961,26 @@ pyvisa returned StatusCode .."</dd>
 <span>(</span><span>fgen, channel, impedance)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Class for controlling a channel on a function generator object</p>
+<div class="desc"><p>Class for controlling a channel on a function generator object</p>
 <h2 id="parameters">Parameters</h2>
 <dl>
-<dt><strong><code>fgen</code></strong> :&ensp;<code>FuncGen</code></dt>
+<dt><strong><code>fgen</code></strong> :&ensp;<code><a title="tektronix_func_gen.FuncGen" href="#tektronix_func_gen.FuncGen">FuncGen</a></code></dt>
 <dd>The function generator object</dd>
-<dt><strong><code>channel</code></strong> :&ensp;{<code>1</code>, <code>2</code>}</dt>
+<dt><strong><code>channel</code></strong> :&ensp;<code>{1, 2}</code></dt>
 <dd>The channel to be controlled</dd>
-<dt><strong><code>impedance</code></strong> :&ensp;{<code>"50ohm"</code>, <code>"highZ"</code>}</dt>
+<dt><strong><code>impedance</code></strong> :&ensp;<code>{"50ohm", "highZ"}</code></dt>
 <dd>Determines voltage limits associated with high impedance (whether the
 instrument is using 50ohm or high Z cannot be controlled through VISA)</dd>
 </dl>
 <h2 id="attributes">Attributes</h2>
 <dl>
-<dt><strong><code>fgen</code></strong> :&ensp;<code>FuncGen</code></dt>
+<dt><strong><code>_fgen</code></strong> :&ensp;<code><a title="tektronix_func_gen.FuncGen" href="#tektronix_func_gen.FuncGen">FuncGen</a></code></dt>
 <dd>The function generator object for which the channel exists</dd>
-<dt><strong><code>channel</code></strong> :&ensp;{<code>1</code>, <code>2</code>}</dt>
-<dd>The channel number</dd>
-<dt><strong><code>impedance</code></strong> :&ensp;{<code>"50ohm"</code>, <code>"highZ"</code>}</dt>
-<dd>Determines voltage limits associated with high impedance (whether the
-instrument is using 50ohm or high Z cannot be controlled through VISA)</dd>
-<dt><strong><code>source</code></strong> :&ensp;<code>str</code></dt>
-<dd>"SOURce{}:" where {} is the channel number</dd>
-<dt><strong><code>settings_units</code></strong> :&ensp;<code>list</code></dt>
-<dd>The units for the settings produced by <a title="tektronix_func_gen.FuncGenChannel.get_settings" href="#tektronix_func_gen.FuncGenChannel.get_settings"><code>FuncGenChannel.get_settings()</code></a></dd>
-<dt><strong><code>state_str</code></strong> :&ensp;<code>dict</code></dt>
-<dd>For conversion from states 1 and 2 to "ON" and "OFF"</dd>
-</dl></section>
+<dt><strong><code>_channel</code></strong> :&ensp;<code>{1, 2}</code></dt>
+<dd>The number of the channel this object is addressing</dd>
+<dt><strong><code>_source</code></strong> :&ensp;<code>str</code></dt>
+<dd>"SOURce{i}:" where {i} is the channel number</dd>
+</dl></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -3075,35 +3000,31 @@ instrument is using 50ohm or high Z cannot be controlled through VISA)</dd>
 
     Attributes
     ----------
-    fgen : `FuncGen`
+    _fgen : `FuncGen`
         The function generator object for which the channel exists
-    channel : {1, 2}
-        The channel number
-    impedance : {&#34;50ohm&#34;, &#34;highZ&#34;}
-        Determines voltage limits associated with high impedance (whether the
-        instrument is using 50ohm or high Z cannot be controlled through VISA)
-    source : str
-        &#34;SOURce{}:&#34; where {} is the channel number
-    settings_units : list
-        The units for the settings produced by `FuncGenChannel.get_settings`
-    state_str : dict
-        For conversion from states 1 and 2 to &#34;ON&#34; and &#34;OFF&#34;
+    _channel : {1, 2}
+        The number of the channel this object is addressing
+    _source : str
+        &#34;SOURce{i}:&#34; where {i} is the channel number
     &#34;&#34;&#34;
 
-    # Attributes
-    state_str = {&#34;1&#34;: &#34;ON&#34;, &#34;0&#34;: &#34;OFF&#34;,
-                  1 : &#34;ON&#34;,  0 : &#34;OFF&#34;}
+    _state_to_str = {&#34;1&#34;: &#34;ON&#34;, &#34;0&#34;: &#34;OFF&#34;, 1: &#34;ON&#34;, 0: &#34;OFF&#34;}
     &#34;&#34;&#34;Dictionary for converting output states to &#34;ON&#34; and &#34;OFF&#34; &#34;&#34;&#34;
 
     def __init__(self, fgen, channel, impedance):
-        self.fgen = fgen
-        self.channel = channel
-        self.source = &#34;SOURce{}:&#34;.format(channel)
+        self._fgen = fgen
+        self._channel = channel
+        self._source = f&#34;SOURce{channel}:&#34;
         self.impedance = impedance
+        &#34;&#34;&#34;{&#34;50ohm&#34;, &#34;highZ&#34;}: Determines voltage limits associated with high
+        impedance (whether the instrument is using 50ohm or high Z cannot be
+        controlled through VISA)&#34;&#34;&#34;
         # Adopt limits dictionary from instrument
-        self.channel_limits = copy.deepcopy(self.fgen.instrument_limits)
+        self.channel_limits = copy.deepcopy(self._fgen.instrument_limits)
+        &#34;&#34;&#34;Channel limits for the individual channel, same form as
+        `FuncGen.instrument_limits`&#34;&#34;&#34;
 
-    def impedance_dependent_limit(self, limit_type):
+    def _impedance_dependent_limit(self, limit_type):
         &#34;&#34;&#34;Check if the limit type is impedance dependent (voltages) or
         not (frequency)
 
@@ -3112,43 +3033,43 @@ instrument is using 50ohm or high Z cannot be controlled through VISA)</dd>
         bool
             `True` if the limit is impedance dependent
         &#34;&#34;&#34;
-        try: # to access the key &#34;min&#34; to check if impedance must be selected
+        try:  # to access the key &#34;min&#34; to check if impedance must be selected
             _ = self.channel_limits[limit_type][0][&#34;min&#34;]
             return False
-        except KeyError: # if the key does not exist
+        except KeyError:  # if the key does not exist
             # The impedance must be selected
             return True
 
     def set_stricter_limits(self):
         &#34;&#34;&#34;Set limits for the voltage and frequency limits of the channel output
         through a series of prompts&#34;&#34;&#34;
-        print(&#34;Set stricter voltage and frequency limits &#34;
-              &#34;for channel {}&#34;.format(self.channel))
+        print(f&#34;Set stricter voltage and frequency limits for channel {self._channel}&#34;)
         print(&#34;Use enter only to leave a limit unchanged.&#34;)
         # Go through the different limits in the instrument_limits dict
-        for limit_type, (inst_limit_dict, unit) in self.fgen.instrument_limits.items():
-            use_impedance = self.impedance_dependent_limit(limit_type)
-            print(&#34;Set {} in {}&#34;.format(limit_type, unit), end=&#34; &#34;)
+        for limit_type, (inst_limit_dict, unit) in self._fgen.instrument_limits.items():
+            use_impedance = self._impedance_dependent_limit(limit_type)
+            print(f&#34;Set {limit_type} in {unit}&#34;, end=&#34; &#34;)
             if use_impedance:
                 inst_limit_dict = inst_limit_dict[self.impedance]
-                print(&#34;[{} impedance limit]&#34;.format(self.impedance))
+                print(f&#34;[{self.impedance} impedance limit]&#34;)
             else:
-                print(&#34;&#34;) # get new line
+                print(&#34;&#34;)  # get new line
             # Go through the min and max for the limit type
             for key, inst_value in inst_limit_dict.items():
                 # prompt for new value
-                new_value = input(&#34;  {} (instrument limit {}{}): &#34;
-                                  &#34;&#34;.format(key, inst_value, unit))
+                new_value = input(f&#34;  {key} (instrument limit {inst_value}{unit}): &#34;)
                 if new_value == &#34;&#34;:
                     # Do not change if empty
                     print(&#34;\tLimit not changed&#34;)
                 else:
-                    try: # to convert to float
+                    try:  # to convert to float
                         new_value = float(new_value)
                     except ValueError:
-                        print(&#34;\tLimit unchanged: Could not convert \&#39;{}\&#39; &#34;
-                              &#34;to float&#34;.format(new_value))
-                        continue # to next item in dict
+                        print(
+                            f&#34;\tLimit unchanged: Could not convert &#39;{new_value}&#39; &#34;
+                            f&#34;to float&#34;
+                        )
+                        continue  # to next item in dict
                     # Set the new limit
                     self.set_limit(limit_type, key, new_value, verbose=True)
 
@@ -3174,10 +3095,10 @@ instrument is using 50ohm or high Z cannot be controlled through VISA)</dd>
             `True` if new limit set, `False` otherwise
         &#34;&#34;&#34;
         # Short hand references
-        inst_limit_dict = self.fgen.instrument_limits[limit_type]
+        inst_limit_dict = self._fgen.instrument_limits[limit_type]
         channel_limit_dict = self.channel_limits[limit_type]
         # Find the instrument limit and unit
-        use_impedance = self.impedance_dependent_limit(limit_type)
+        use_impedance = self._impedance_dependent_limit(limit_type)
         if use_impedance:
             inst_value = inst_limit_dict[0][self.impedance][bound]
         else:
@@ -3191,7 +3112,7 @@ instrument is using 50ohm or high Z cannot be controlled through VISA)</dd>
             current_min = channel_limit_dict[0][&#34;min&#34;]
         larger_than_min = new_value &gt; current_min
         acceptable_max = bound == &#34;max&#34; and new_value &lt; inst_value and larger_than_min
-        if acceptable_min or acceptable_max: # within the limits
+        if acceptable_min or acceptable_max:  # within the limits
             # Set the new channel_limit, using the impedance depending on the
             # limit type. Beware that the shorthand cannot be used, as this
             # only changes the shorthand not the dictionary itself
@@ -3200,57 +3121,61 @@ instrument is using 50ohm or high Z cannot be controlled through VISA)</dd>
             else:
                 self.channel_limits[limit_type][0][bound] = new_value
             if verbose:
-                print(&#34;\tNew limit set {}{}&#34;.format(new_value, unit))
+                print(f&#34;\tNew limit set {new_value}{unit}&#34;)
             return True
-        elif verbose: # print description of why the limit was not set
+        if verbose:  # print description of why the limit was not set
             if larger_than_min:
                 reason = &#34;larger&#34; if bound == &#34;max&#34; else &#34;smaller&#34;
-                print(&#34;\tNew limit NOT set: {}{unit} is {} than the instrument &#34;
-                      &#34;limit ({}{unit})&#34;.format(new_value, reason, inst_value,
-                                                unit=unit))
+                print(
+                    f&#34;\tNew limit NOT set: {new_value}{unit} is {reason} than &#34;
+                    f&#34;the instrument limit ({inst_value}{unit})&#34;
+                )
             else:
-                print(&#34;\tNew limit NOT set: {}{unit} is smaller than the &#34;
-                      &#34;current set minimum ({}{unit})&#34;.format(new_value,
-                                                              current_min,
-                                                              unit=unit))
+                print(
+                    f&#34;\tNew limit NOT set: {new_value}{unit} is smaller than the &#34;
+                    f&#34;current set minimum ({current_min}{unit})&#34;
+                )
         return False
 
     # Get currently used parameters from function generator
     def get_output_state(self):
         &#34;&#34;&#34;Returns &#34;0&#34; for &#34;OFF&#34;, &#34;1&#34; for &#34;ON&#34; &#34;&#34;&#34;
-        return self.fgen.query(&#34;OUTPut{}:STATe?&#34;.format(self.channel))
+        return self._fgen.query(f&#34;OUTPut{self._channel}:STATe?&#34;)
 
     def get_function(self):
         &#34;&#34;&#34;Returns string of function name&#34;&#34;&#34;
-        return self.fgen.query(&#34;{}FUNCtion:SHAPe?&#34;.format(self.source))
+        return self._fgen.query(f&#34;{self._source}FUNCtion:SHAPe?&#34;)
 
     def get_amplitude(self):
         &#34;&#34;&#34;Returns peak-to-peak voltage in volts&#34;&#34;&#34;
-        return float(self.fgen.query(&#34;{}VOLTage:AMPLitude?&#34;.format(self.source)))
+        return float(self._fgen.query(f&#34;{self._source}VOLTage:AMPLitude?&#34;))
 
     def get_offset(self):
         &#34;&#34;&#34;Returns offset voltage in volts&#34;&#34;&#34;
-        return float(self.fgen.query(&#34;{}VOLTage:OFFSet?&#34;.format(self.source)))
+        return float(self._fgen.query(f&#34;{self._source}VOLTage:OFFSet?&#34;))
 
     def get_frequency(self):
         &#34;&#34;&#34;Returns frequency in Hertz&#34;&#34;&#34;
-        return float(self.fgen.query(&#34;{}FREQuency?&#34;.format(self.source)))
+        return float(self._fgen.query(f&#34;{self._source}FREQuency?&#34;))
 
     # Get limits set in the channel class
     def get_frequency_lims(self):
         &#34;&#34;&#34;Returns list of min and max frequency limits&#34;&#34;&#34;
-        return [self.channel_limits[&#34;frequency lims&#34;][0][key]
-                for key in [&#34;min&#34;, &#34;max&#34;]]
+        return [self.channel_limits[&#34;frequency lims&#34;][0][key] for key in [&#34;min&#34;, &#34;max&#34;]]
 
     def get_voltage_lims(self):
         &#34;&#34;&#34;Returns list of min and max voltage limits for the current impedance&#34;&#34;&#34;
-        return [self.channel_limits[&#34;voltage lims&#34;][0][self.impedance][key]
-                for key in [&#34;min&#34;, &#34;max&#34;]]
+        return [
+            self.channel_limits[&#34;voltage lims&#34;][0][self.impedance][key]
+            for key in [&#34;min&#34;, &#34;max&#34;]
+        ]
 
     def get_amplitude_lims(self):
         &#34;&#34;&#34;Returns list of min and max amplitude limits for the current impedance&#34;&#34;&#34;
-        return [self.channel_limits[&#34;amplitude lims&#34;][0][self.impedance][key]
-                for key in [&#34;min&#34;, &#34;max&#34;]]
+        return [
+            self.channel_limits[&#34;amplitude lims&#34;][0][self.impedance][key]
+            for key in [&#34;min&#34;, &#34;max&#34;]
+        ]
 
     def get_settings(self):
         &#34;&#34;&#34;Get the settings for the channel
@@ -3262,11 +3187,13 @@ instrument is using 50ohm or high Z cannot be controlled through VISA)</dd>
             function, amplitude, offset, and frequency and values tuples of
             the corresponding return and unit
         &#34;&#34;&#34;
-        return {&#34;output&#34;:    (self.state_str[self.get_output_state()], &#34;&#34;),
-                &#34;function&#34;:  (self.get_function(),  &#34;&#34;),
-                &#34;amplitude&#34;: (self.get_amplitude(), &#34;Vpp&#34;),
-                &#34;offset&#34;:    (self.get_offset(),    &#34;V&#34;),
-                &#34;frequency&#34;: (self.get_frequency(), &#34;Hz&#34;)}
+        return {
+            &#34;output&#34;: (self._state_to_str[self.get_output_state()], &#34;&#34;),
+            &#34;function&#34;: (self.get_function(), &#34;&#34;),
+            &#34;amplitude&#34;: (self.get_amplitude(), &#34;Vpp&#34;),
+            &#34;offset&#34;: (self.get_offset(), &#34;V&#34;),
+            &#34;frequency&#34;: (self.get_frequency(), &#34;Hz&#34;),
+        }
 
     def print_settings(self):
         &#34;&#34;&#34;Print the settings currently in use for the channel (Recommended
@@ -3274,11 +3201,10 @@ instrument is using 50ohm or high Z cannot be controlled through VISA)</dd>
         &#34;&#34;&#34;
         settings = self.get_settings()
         longest_key = max([len(key) for key in settings.keys()])
-        print(&#34;\nCurrent settings for channel {}&#34;.format(self.channel))
+        print(&#34;\nCurrent settings for channel {}&#34;.format(self._channel))
         print(&#34;==============================&#34;)
         for key, (val, unit) in settings.items():
-            print(&#34;{:&gt;{num_char}s} {} {}&#34;.format(key, val, unit,
-                                                 num_char=longest_key))
+            print(&#34;{:&gt;{num_char}s} {} {}&#34;.format(key, val, unit, num_char=longest_key))
 
     def set_settings(self, settings):
         &#34;&#34;&#34;Set the settings of the channel with a settings dictionary. Will
@@ -3295,11 +3221,11 @@ instrument is using 50ohm or high Z cannot be controlled through VISA)</dd>
         # combination of settings
         self.set_output_state(&#34;OFF&#34;)
         # Set settings according to dictionary
-        self.set_function(settings[&#39;function&#39;][0])
-        self.set_amplitude(settings[&#39;amplitude&#39;][0])
-        self.set_offset(settings[&#39;offset&#39;][0])
-        self.set_frequency(settings[&#39;frequency&#39;][0])
-        self.set_output_state(settings[&#39;output&#39;][0])
+        self.set_function(settings[&#34;function&#34;][0])
+        self.set_amplitude(settings[&#34;amplitude&#34;][0])
+        self.set_offset(settings[&#34;offset&#34;][0])
+        self.set_frequency(settings[&#34;frequency&#34;][0])
+        self.set_output_state(settings[&#34;output&#34;][0])
 
     def set_output_state(self, state):
         &#34;&#34;&#34;Enables or diables the output of the channel
@@ -3313,21 +3239,22 @@ instrument is using 50ohm or high Z cannot be controlled through VISA)</dd>
         Raises
         ------
         NotSetError
-            If `self.fgen.verify_param_set` is `True` and the value after
+            If `self._fgen.verify_param_set` is `True` and the value after
             applying the set function does not match the value returned by the
             get function
         &#34;&#34;&#34;
-        err_msg = &#34;turn channel {} to state {}&#34;.format(self.channel, state)
-        self.fgen.write(&#34;OUTPut{}:STATe {}&#34;.format(self.channel, state),
-                                            custom_err_message=err_msg)
-        if self.fgen.verify_param_set:
+        err_msg = f&#34;turn channel {self._channel} to state {state}&#34;
+        self._fgen.write(
+            f&#34;OUTPut{self._channel}:STATe {state}&#34;, custom_err_message=err_msg
+        )
+        if self._fgen.verify_param_set:
             actual_state = self.get_output_state()
             if not actual_state == state:
-                msg = (&#34;Channel {} was not turned {}, it is {}.\n&#34;
-                       &#34;Error from the instrument: {}&#34;
-                       &#34;&#34;.format(self.channel, state,
-                                 self.state_str[actual_state],
-                                 self.fgen.get_error()))
+                msg = (
+                    f&#34;Channel {self._channel} was not turned {state}, it is &#34;
+                    f&#34;{self._state_to_str[actual_state]}.\n&#34;
+                    f&#34;Error from the instrument: {self._fgen.get_error()}&#34;
+                )
                 raise NotSetError(msg)
 
     def get_output(self):
@@ -3356,21 +3283,22 @@ instrument is using 50ohm or high Z cannot be controlled through VISA)</dd>
         Raises
         ------
         NotSetError
-            If `self.fgen.verify_param_set` is `True` and the value after
+            If `self._fgen.verify_param_set` is `True` and the value after
             applying the set function does not match the value returned by the
             get function
         &#34;&#34;&#34;
-        cmd = &#34;{}FUNCtion:SHAPe {}&#34;.format(self.source, shape)
-        self.fgen.write(cmd, custom_err_message=&#34;set function {}&#34;.format(shape))
-        if self.fgen.verify_param_set:
+        cmd = f&#34;{self._source}FUNCtion:SHAPe {shape}&#34;
+        self._fgen.write(cmd, custom_err_message=f&#34;set function {shape}&#34;)
+        if self._fgen.verify_param_set:
             actual_shape = self.get_function()
             if not actual_shape == shape:
-                msg = (&#34;Function {} was not set on channel {}, it is {}. &#34;
-                       &#34;Check that the function name is correctly spelt. &#34;
-                       &#34;Run set_function.__doc__ to see available shapes.\n&#34;
-                       &#34;Error from the instrument: {}&#34;
-                       &#34;&#34;.format(shape, self.channel, actual_shape,
-                                 self.fgen.get_error()))
+                msg = (
+                    f&#34;Function {shape} was not set on channel {self._channel}, &#34;
+                    f&#34;it is {actual_shape}. Check that the function name is &#34;
+                    f&#34;correctly spelt. Look up `set_function.__doc__` to see &#34;
+                    f&#34;available shapes.\n Error from the instrument: &#34;
+                    f&#34;{self._fgen.get_error()}&#34;
+                )
                 raise NotSetError(msg)
 
     def set_amplitude(self, amplitude):
@@ -3385,56 +3313,62 @@ instrument is using 50ohm or high Z cannot be controlled through VISA)</dd>
         Raises
         ------
         NotSetError
-            If `self.fgen.verify_param_set` is `True` and the value after
+            If `self._fgen.verify_param_set` is `True` and the value after
             applying the set function does not match the value returned by the
             get function
         &#34;&#34;&#34;
         # Check if keyword min or max is given
         if str(amplitude).lower() in [&#34;min&#34;, &#34;max&#34;]:
-            unit = &#34;&#34; # no unit for MIN/MAX
+            unit = &#34;&#34;  # no unit for MIN/MAX
             # Look up what the limit is for this keyword
-            amplitude = self.channel_limits[&#34;amplitude lims&#34;][0][self.impedance][str(amplitude).lower()]
+            amplitude = self.channel_limits[&#34;amplitude lims&#34;][0][self.impedance][
+                str(amplitude).lower()
+            ]
         else:
             unit = &#34;Vpp&#34;
             # Check if the given amplitude is within the current limits
             min_ampl, max_ampl = self.get_amplitude_lims()
             if amplitude &lt; min_ampl or amplitude &gt; max_ampl:
-                msg = (&#34;Could not set the amplitude {}{unit} as it is not &#34;
-                       &#34;within the amplitude limits set for the instrument &#34;
-                       &#34;[{}, {}]{unit}&#34;.format(amplitude, min_ampl, max_ampl,
-                                               unit=unit))
+                msg = (
+                    f&#34;Could not set the amplitude {amplitude}{unit} as it &#34;
+                    f&#34;is not within the amplitude limits set for the instrument &#34;
+                    f&#34;[{min_ampl}, {max_ampl}]{unit}&#34;
+                )
                 raise NotSetError(msg)
         # Check that the new amplitude will not violate voltage limits
         min_volt, max_volt = self.get_voltage_lims()
         current_offset = self.get_offset()
-        if (amplitude/2-current_offset &lt; min_volt or
-            amplitude/2+current_offset &gt; max_volt):
-            msg = (&#34;Could not set the amplitude {}{unit} as the amplitude &#34;
-                   &#34;combined with the offset ({}V) will be outside the &#34;
-                   &#34;absolute voltage limits [{}, {}]{unit}&#34;
-                   &#34;&#34;.format(amplitude, current_offset, min_volt, max_volt,
-                             unit=unit))
+        if (
+            amplitude / 2 - current_offset &lt; min_volt
+            or amplitude / 2 + current_offset &gt; max_volt
+        ):
+            msg = (
+                f&#34;Could not set the amplitude {amplitude}{unit} as the amplitude &#34;
+                f&#34;combined with the offset ({current_offset}V) will be outside the &#34;
+                f&#34;absolute voltage limits [{min_volt}, {max_volt}]{unit}&#34;
+            )
             raise NotSetError(msg)
         # Set the amplitude
-        cmd = &#34;{}VOLTage:LEVel {}{}&#34;.format(self.source, amplitude, unit)
-        err_msg = &#34;set amplitude {}{}&#34;.format(amplitude, unit)
-        self.fgen.write(cmd, custom_err_message=err_msg)
+        cmd = f&#34;{self._source}VOLTage:LEVel {amplitude}{unit}&#34;
+        err_msg = f&#34;set amplitude {amplitude}{unit}&#34;
+        self._fgen.write(cmd, custom_err_message=err_msg)
         # Verify that the amplitude has been set
-        if self.fgen.verify_param_set:
+        if self._fgen.verify_param_set:
             actual_amplitude = self.get_amplitude()
             # Multiply with the appropriate factor according to SI prefix, or
             # if string is empty, use the value looked up from channel_limits earlier
             if not unit == &#34;&#34;:
-                check_amplitude = amplitude*self.SI_prefix_to_factor(unit)
+                check_amplitude = amplitude * _SI_prefix_to_factor(unit)
             else:
-                 check_amplitude = amplitude
+                check_amplitude = amplitude
             if not actual_amplitude == check_amplitude:
-                msg = (&#34;Amplitude {}{} was not set on channel {}, it is &#34;
-                       &#34;{}Vpp. Check that the number is within the possible &#34;
-                       &#34;range and in the correct format.\nError from the &#34;
-                       &#34;instrument: {}&#34;
-                       &#34;&#34;.format(amplitude, unit, self.channel,
-                                 actual_amplitude, self.fgen.get_error()))
+                msg = (
+                    f&#34;Amplitude {amplitude}{unit} was not set on channel &#34;
+                    f&#34;{self._channel}, it is {actual_amplitude}Vpp. Check that &#34;
+                    f&#34; the number is within the possible range and in the &#34;
+                    f&#34;correct format.\nError from the instrument: &#34;
+                    f&#34;{self._fgen.get_error()}&#34;
+                )
                 raise NotSetError(msg)
 
     def set_offset(self, offset, unit=&#34;V&#34;):
@@ -3449,174 +3383,108 @@ instrument is using 50ohm or high Z cannot be controlled through VISA)</dd>
         Raises
         ------
         NotSetError
-            If `self.fgen.verify_param_set` is `True` and the value after
+            If `self._fgen.verify_param_set` is `True` and the value after
             applying the set function does not match the value returned by the
             get function
         &#34;&#34;&#34;
         # Check that the new offset will not violate voltage limits
         min_volt, max_volt = self.get_voltage_lims()
         current_amplitude = self.get_amplitude()
-        if (current_amplitude/2-offset &lt; min_volt or
-            current_amplitude/2+offset &gt; max_volt):
-            msg = (&#34;Could not set the offset {}{unit} as the offset combined&#34;
-                   &#34;with the amplitude ({}V) will be outside the absolute &#34;
-                   &#34;voltage limits [{}, {}]{unit}&#34;.format(offset,
-                                                         current_amplitude,
-                                                         min_volt, max_volt,
-                                                         unit=unit))
+        offset = _SI_prefix_to_factor(unit) * offset
+        if (
+            current_amplitude / 2 - offset &lt; min_volt
+            or current_amplitude / 2 + offset &gt; max_volt
+        ):
+            msg = (
+                f&#34;Could not set the offset {offset}V as the offset combined &#34;
+                f&#34;with the amplitude ({current_amplitude}V) will be outside &#34;
+                f&#34;the absolute voltage limits [{min_volt}, {max_volt}]V&#34;
+            )
             raise NotSetError(msg)
         # Set the offset
-        cmd = &#34;{}VOLTage:LEVel:OFFSet {}{}&#34;.format(self.source, offset, unit)
-        err_msg = &#34;set offset {}{}&#34;.format(offset, unit)
-        self.fgen.write(cmd, custom_err_message=err_msg)
+        cmd = f&#34;{self._source}VOLTage:LEVel:OFFSet {offset}{unit}&#34;
+        err_msg = f&#34;set offset {offset}{unit}&#34;
+        self._fgen.write(cmd, custom_err_message=err_msg)
         # Verify that the offset has been set
-        if self.fgen.verify_param_set:
+        if self._fgen.verify_param_set:
             actual_offset = self.get_offset()
             # Multiply with the appropriate factor according to SI prefix
-            check_offset = offset*self.SI_prefix_to_factor(unit)
+            check_offset = offset * _SI_prefix_to_factor(unit)
             if not actual_offset == check_offset:
-                msg = (&#34;Offset {}{} was not set on channel {}, it is {}V. &#34;
-                       &#34;Check that the number is within the possible range and &#34;
-                       &#34;in the correct format.\nError from the instrument: {}&#34;
-                       &#34;&#34;.format(offset, unit, self.channel, actual_offset,
-                                 self.fgen.get_error()))
+                msg = (
+                    f&#34;Offset {offset}{unit} was not set on channel &#34;
+                    f&#34;{self._channel}, it is {actual_offset}V. Check that the &#34;
+                    f&#34;number is within the possible range and in the correct &#34;
+                    f&#34;format.\nError from the instrument: {self._fgen.get_error()}&#34;
+                )
                 raise NotSetError(msg)
 
     def set_frequency(self, freq, unit=&#34;Hz&#34;):
-        &#34;&#34;&#34;Set the frequency in Hertz (or kHz, MHz, see options)
+        &#34;&#34;&#34;Set the frequency in Hertz (or mHz, kHz, MHz, see options)
 
         Parameters
         ----------
         freq : float
             The resolution is 1 μHz or 12 digits.
-        unit : {Hz, kHz, MHz}, default Hz
+        unit : {mHz, Hz, kHz, MHz}, default Hz
 
         Raises
         ------
         NotSetError
-            If `self.fgen.verify_param_set` is `True` and the value after
+            If `self._fgen.verify_param_set` is `True` and the value after
             applying the set function does not match the value returned by the
             get function
         &#34;&#34;&#34;
-        if str(freq).lower() in [&#34;min&#34;, &#34;max&#34;]: # handle min and max keywords
-            unit = &#34;&#34; # no unit for MIN/MAX
+        if str(freq).lower() in [&#34;min&#34;, &#34;max&#34;]:  # handle min and max keywords
+            unit = &#34;&#34;  # no unit for MIN/MAX
             # Look up what the limit is for this keyword
             freq = self.channel_limits[&#34;frequency lims&#34;][0][str(freq).lower()]
         else:
             # Check if the given frequency is within the current limits
             min_freq, max_freq = self.get_frequency_lims()
+            freq = _SI_prefix_to_factor(unit) * freq
             if freq &lt; min_freq or freq &gt; max_freq:
-                msg = (&#34;Could not set the frequency {}{} as it is not within &#34;
-                       &#34;the frequency limits set for the instrument [{}, {}]&#34;
-                       &#34;Hz&#34;.format(freq, unit, min_freq, max_freq))
+                msg = (
+                    f&#34;Could not set the frequency {freq}Hz as it is not &#34;
+                    f&#34;within the frequency limits set for the instrument &#34;
+                    f&#34;[{min_freq}, {max_freq}]Hz&#34;
+                )
                 raise NotSetError(msg)
-        # Check that the new amplitude will not violate voltage limits
-        min_volt, max_volt = self.get_voltage_lims()
         # Set the frequency
-        self.fgen.write(&#34;{}FREQuency:FIXed {}{}&#34;.format(self.source, freq, unit),
-                            custom_err_message=&#34;set frequency {}{}&#34;.format(freq, unit))
+        self._fgen.write(
+            f&#34;{self._source}FREQuency:FIXed {freq}{unit}&#34;,
+            custom_err_message=f&#34;set frequency {freq}{unit}&#34;,
+        )
         # Verify that the amplitude has been set
-        if self.fgen.verify_param_set:
+        if self._fgen.verify_param_set:
             actual_freq = self.get_frequency()
             # Multiply with the appropriate factor according to SI prefix, or
             # if string is empty, use the value looked up from channel_limits earlier
             if not unit == &#34;&#34;:
-                check_freq = freq*self.SI_prefix_to_factor(unit)
+                check_freq = freq * _SI_prefix_to_factor(unit)
             else:
-                check_freq =  freq
+                check_freq = freq
             if not actual_freq == check_freq:
-                msg = (&#34;Frequency {}{} was not set on channel {}, it is {}Hz. &#34;
-                &#34;Check that the number is within the possible range and in &#34;
-                &#34;the correct format.\nError from the instrument: {}&#34;
-                &#34;&#34;.format(freq, unit, self.channel, actual_freq,
-                            self.fgen.get_error()))
-                raise NotSetError(msg)
-
-
-    ## ~~~~~~~~~~~~~~~~~~~~~~~ AUXILLIARY ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ##
-
-    @staticmethod
-    def SI_prefix_to_factor(unit):
-        &#34;&#34;&#34;Convert an SI prefix to a numerical factor
-
-        Parameters
-        ----------
-        unit : str
-            The unit whose first character is checked against the list of
-            prefactors {&#34;M&#34;: 1e6, &#34;k&#34;: 1e3, &#34;m&#34;: 1e-3}
-
-        Returns
-        -------
-        factor : float or `None`
-            The appropriate factor or 1 if not found in the list, or `None`
-            if the unit string is empty
-        &#34;&#34;&#34;
-        # SI prefix to numerical value
-        SI_conversion = {&#34;M&#34;:1e6, &#34;k&#34;:1e3, &#34;m&#34;:1e-3}
-        try:  # using the unit&#39;s first character as key in the dictionary
-            factor = SI_conversion[unit[0]]
-        except KeyError:  # if the entry does not exist
-            factor = 1
-        except IndexError:  # if the unit string is empty
-            factor = None
-        return factor</code></pre>
+                msg = (
+                    f&#34;Frequency {freq}{unit} was not set on channel {self._channel}&#34;
+                    f&#34;, it is {actual_freq}Hz. Check that the number is within &#34;
+                    f&#34;the possible range and in the correct format.\nError &#34;
+                    f&#34;from the instrument: {self._fgen.get_error()}&#34;
+                )
+                raise NotSetError(msg)</code></pre>
 </details>
-<h3>Class variables</h3>
+<h3>Instance variables</h3>
 <dl>
-<dt id="tektronix_func_gen.FuncGenChannel.state_str"><code class="name">var <span class="ident">state_str</span></code></dt>
+<dt id="tektronix_func_gen.FuncGenChannel.channel_limits"><code class="name">var <span class="ident">channel_limits</span></code></dt>
 <dd>
-<section class="desc"><p>Dictionary for converting output states to "ON" and "OFF"</p></section>
+<div class="desc"><p>Channel limits for the individual channel, same form as
+<code><a title="tektronix_func_gen.FuncGen.instrument_limits" href="#tektronix_func_gen.FuncGen.instrument_limits">FuncGen.instrument_limits</a></code></p></div>
 </dd>
-</dl>
-<h3>Static methods</h3>
-<dl>
-<dt id="tektronix_func_gen.FuncGenChannel.SI_prefix_to_factor"><code class="name flex">
-<span>def <span class="ident">SI_prefix_to_factor</span></span>(<span>unit)</span>
-</code></dt>
+<dt id="tektronix_func_gen.FuncGenChannel.impedance"><code class="name">var <span class="ident">impedance</span></code></dt>
 <dd>
-<section class="desc"><p>Convert an SI prefix to a numerical factor</p>
-<h2 id="parameters">Parameters</h2>
-<dl>
-<dt><strong><code>unit</code></strong> :&ensp;<code>str</code></dt>
-<dd>The unit whose first character is checked against the list of
-prefactors {"M": 1e6, "k": 1e3, "m": 1e-3}</dd>
-</dl>
-<h2 id="returns">Returns</h2>
-<dl>
-<dt><strong><code>factor</code></strong> :&ensp;<code>float</code> or <code>None</code></dt>
-<dd>The appropriate factor or 1 if not found in the list, or <code>None</code>
-if the unit string is empty</dd>
-</dl></section>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">@staticmethod
-def SI_prefix_to_factor(unit):
-    &#34;&#34;&#34;Convert an SI prefix to a numerical factor
-
-    Parameters
-    ----------
-    unit : str
-        The unit whose first character is checked against the list of
-        prefactors {&#34;M&#34;: 1e6, &#34;k&#34;: 1e3, &#34;m&#34;: 1e-3}
-
-    Returns
-    -------
-    factor : float or `None`
-        The appropriate factor or 1 if not found in the list, or `None`
-        if the unit string is empty
-    &#34;&#34;&#34;
-    # SI prefix to numerical value
-    SI_conversion = {&#34;M&#34;:1e6, &#34;k&#34;:1e3, &#34;m&#34;:1e-3}
-    try:  # using the unit&#39;s first character as key in the dictionary
-        factor = SI_conversion[unit[0]]
-    except KeyError:  # if the entry does not exist
-        factor = 1
-    except IndexError:  # if the unit string is empty
-        factor = None
-    return factor</code></pre>
-</details>
+<div class="desc"><p>{"50ohm", "highZ"}: Determines voltage limits associated with high
+impedance (whether the instrument is using 50ohm or high Z cannot be
+controlled through VISA)</p></div>
 </dd>
 </dl>
 <h3>Methods</h3>
@@ -3625,93 +3493,94 @@ def SI_prefix_to_factor(unit):
 <span>def <span class="ident">get_amplitude</span></span>(<span>self)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Returns peak-to-peak voltage in volts</p></section>
+<div class="desc"><p>Returns peak-to-peak voltage in volts</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">def get_amplitude(self):
     &#34;&#34;&#34;Returns peak-to-peak voltage in volts&#34;&#34;&#34;
-    return float(self.fgen.query(&#34;{}VOLTage:AMPLitude?&#34;.format(self.source)))</code></pre>
+    return float(self._fgen.query(f&#34;{self._source}VOLTage:AMPLitude?&#34;))</code></pre>
 </details>
 </dd>
 <dt id="tektronix_func_gen.FuncGenChannel.get_amplitude_lims"><code class="name flex">
 <span>def <span class="ident">get_amplitude_lims</span></span>(<span>self)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Returns list of min and max amplitude limits for the current impedance</p></section>
+<div class="desc"><p>Returns list of min and max amplitude limits for the current impedance</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">def get_amplitude_lims(self):
     &#34;&#34;&#34;Returns list of min and max amplitude limits for the current impedance&#34;&#34;&#34;
-    return [self.channel_limits[&#34;amplitude lims&#34;][0][self.impedance][key]
-            for key in [&#34;min&#34;, &#34;max&#34;]]</code></pre>
+    return [
+        self.channel_limits[&#34;amplitude lims&#34;][0][self.impedance][key]
+        for key in [&#34;min&#34;, &#34;max&#34;]
+    ]</code></pre>
 </details>
 </dd>
 <dt id="tektronix_func_gen.FuncGenChannel.get_frequency"><code class="name flex">
 <span>def <span class="ident">get_frequency</span></span>(<span>self)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Returns frequency in Hertz</p></section>
+<div class="desc"><p>Returns frequency in Hertz</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">def get_frequency(self):
     &#34;&#34;&#34;Returns frequency in Hertz&#34;&#34;&#34;
-    return float(self.fgen.query(&#34;{}FREQuency?&#34;.format(self.source)))</code></pre>
+    return float(self._fgen.query(f&#34;{self._source}FREQuency?&#34;))</code></pre>
 </details>
 </dd>
 <dt id="tektronix_func_gen.FuncGenChannel.get_frequency_lims"><code class="name flex">
 <span>def <span class="ident">get_frequency_lims</span></span>(<span>self)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Returns list of min and max frequency limits</p></section>
+<div class="desc"><p>Returns list of min and max frequency limits</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">def get_frequency_lims(self):
     &#34;&#34;&#34;Returns list of min and max frequency limits&#34;&#34;&#34;
-    return [self.channel_limits[&#34;frequency lims&#34;][0][key]
-            for key in [&#34;min&#34;, &#34;max&#34;]]</code></pre>
+    return [self.channel_limits[&#34;frequency lims&#34;][0][key] for key in [&#34;min&#34;, &#34;max&#34;]]</code></pre>
 </details>
 </dd>
 <dt id="tektronix_func_gen.FuncGenChannel.get_function"><code class="name flex">
 <span>def <span class="ident">get_function</span></span>(<span>self)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Returns string of function name</p></section>
+<div class="desc"><p>Returns string of function name</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">def get_function(self):
     &#34;&#34;&#34;Returns string of function name&#34;&#34;&#34;
-    return self.fgen.query(&#34;{}FUNCtion:SHAPe?&#34;.format(self.source))</code></pre>
+    return self._fgen.query(f&#34;{self._source}FUNCtion:SHAPe?&#34;)</code></pre>
 </details>
 </dd>
 <dt id="tektronix_func_gen.FuncGenChannel.get_offset"><code class="name flex">
 <span>def <span class="ident">get_offset</span></span>(<span>self)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Returns offset voltage in volts</p></section>
+<div class="desc"><p>Returns offset voltage in volts</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">def get_offset(self):
     &#34;&#34;&#34;Returns offset voltage in volts&#34;&#34;&#34;
-    return float(self.fgen.query(&#34;{}VOLTage:OFFSet?&#34;.format(self.source)))</code></pre>
+    return float(self._fgen.query(f&#34;{self._source}VOLTage:OFFSet?&#34;))</code></pre>
 </details>
 </dd>
 <dt id="tektronix_func_gen.FuncGenChannel.get_output"><code class="name flex">
 <span>def <span class="ident">get_output</span></span>(<span>self)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Wrapper for get_output_state</p></section>
+<div class="desc"><p>Wrapper for get_output_state</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -3725,28 +3594,28 @@ def SI_prefix_to_factor(unit):
 <span>def <span class="ident">get_output_state</span></span>(<span>self)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Returns "0" for "OFF", "1" for "ON"</p></section>
+<div class="desc"><p>Returns "0" for "OFF", "1" for "ON"</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">def get_output_state(self):
     &#34;&#34;&#34;Returns &#34;0&#34; for &#34;OFF&#34;, &#34;1&#34; for &#34;ON&#34; &#34;&#34;&#34;
-    return self.fgen.query(&#34;OUTPut{}:STATe?&#34;.format(self.channel))</code></pre>
+    return self._fgen.query(f&#34;OUTPut{self._channel}:STATe?&#34;)</code></pre>
 </details>
 </dd>
 <dt id="tektronix_func_gen.FuncGenChannel.get_settings"><code class="name flex">
 <span>def <span class="ident">get_settings</span></span>(<span>self)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Get the settings for the channel</p>
+<div class="desc"><p>Get the settings for the channel</p>
 <h2 id="returns">Returns</h2>
 <dl>
 <dt><strong><code>current_settings</code></strong> :&ensp;<code>dict</code></dt>
 <dd>Settings currently in use as a dictionary with keys output,
 function, amplitude, offset, and frequency and values tuples of
 the corresponding return and unit</dd>
-</dl></section>
+</dl></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -3761,66 +3630,38 @@ the corresponding return and unit</dd>
         function, amplitude, offset, and frequency and values tuples of
         the corresponding return and unit
     &#34;&#34;&#34;
-    return {&#34;output&#34;:    (self.state_str[self.get_output_state()], &#34;&#34;),
-            &#34;function&#34;:  (self.get_function(),  &#34;&#34;),
-            &#34;amplitude&#34;: (self.get_amplitude(), &#34;Vpp&#34;),
-            &#34;offset&#34;:    (self.get_offset(),    &#34;V&#34;),
-            &#34;frequency&#34;: (self.get_frequency(), &#34;Hz&#34;)}</code></pre>
+    return {
+        &#34;output&#34;: (self._state_to_str[self.get_output_state()], &#34;&#34;),
+        &#34;function&#34;: (self.get_function(), &#34;&#34;),
+        &#34;amplitude&#34;: (self.get_amplitude(), &#34;Vpp&#34;),
+        &#34;offset&#34;: (self.get_offset(), &#34;V&#34;),
+        &#34;frequency&#34;: (self.get_frequency(), &#34;Hz&#34;),
+    }</code></pre>
 </details>
 </dd>
 <dt id="tektronix_func_gen.FuncGenChannel.get_voltage_lims"><code class="name flex">
 <span>def <span class="ident">get_voltage_lims</span></span>(<span>self)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Returns list of min and max voltage limits for the current impedance</p></section>
+<div class="desc"><p>Returns list of min and max voltage limits for the current impedance</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">def get_voltage_lims(self):
     &#34;&#34;&#34;Returns list of min and max voltage limits for the current impedance&#34;&#34;&#34;
-    return [self.channel_limits[&#34;voltage lims&#34;][0][self.impedance][key]
-            for key in [&#34;min&#34;, &#34;max&#34;]]</code></pre>
-</details>
-</dd>
-<dt id="tektronix_func_gen.FuncGenChannel.impedance_dependent_limit"><code class="name flex">
-<span>def <span class="ident">impedance_dependent_limit</span></span>(<span>self, limit_type)</span>
-</code></dt>
-<dd>
-<section class="desc"><p>Check if the limit type is impedance dependent (voltages) or
-not (frequency)</p>
-<h2 id="returns">Returns</h2>
-<dl>
-<dt><code>bool</code></dt>
-<dd><code>True</code> if the limit is impedance dependent</dd>
-</dl></section>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def impedance_dependent_limit(self, limit_type):
-    &#34;&#34;&#34;Check if the limit type is impedance dependent (voltages) or
-    not (frequency)
-
-    Returns
-    -------
-    bool
-        `True` if the limit is impedance dependent
-    &#34;&#34;&#34;
-    try: # to access the key &#34;min&#34; to check if impedance must be selected
-        _ = self.channel_limits[limit_type][0][&#34;min&#34;]
-        return False
-    except KeyError: # if the key does not exist
-        # The impedance must be selected
-        return True</code></pre>
+    return [
+        self.channel_limits[&#34;voltage lims&#34;][0][self.impedance][key]
+        for key in [&#34;min&#34;, &#34;max&#34;]
+    ]</code></pre>
 </details>
 </dd>
 <dt id="tektronix_func_gen.FuncGenChannel.print_settings"><code class="name flex">
 <span>def <span class="ident">print_settings</span></span>(<span>self)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Print the settings currently in use for the channel (Recommended
-to use the <a title="tektronix_func_gen.FuncGen.print_settings" href="#tektronix_func_gen.FuncGen.print_settings"><code>FuncGen.print_settings()</code></a> for printing both channels)</p></section>
+<div class="desc"><p>Print the settings currently in use for the channel (Recommended
+to use the <code><a title="tektronix_func_gen.FuncGen.print_settings" href="#tektronix_func_gen.FuncGen.print_settings">FuncGen.print_settings()</a></code> for printing both channels)</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -3831,31 +3672,30 @@ to use the <a title="tektronix_func_gen.FuncGen.print_settings" href="#tektronix
     &#34;&#34;&#34;
     settings = self.get_settings()
     longest_key = max([len(key) for key in settings.keys()])
-    print(&#34;\nCurrent settings for channel {}&#34;.format(self.channel))
+    print(&#34;\nCurrent settings for channel {}&#34;.format(self._channel))
     print(&#34;==============================&#34;)
     for key, (val, unit) in settings.items():
-        print(&#34;{:&gt;{num_char}s} {} {}&#34;.format(key, val, unit,
-                                             num_char=longest_key))</code></pre>
+        print(&#34;{:&gt;{num_char}s} {} {}&#34;.format(key, val, unit, num_char=longest_key))</code></pre>
 </details>
 </dd>
 <dt id="tektronix_func_gen.FuncGenChannel.set_amplitude"><code class="name flex">
 <span>def <span class="ident">set_amplitude</span></span>(<span>self, amplitude)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Set the peak-to-peak amplitude in volts</p>
+<div class="desc"><p>Set the peak-to-peak amplitude in volts</p>
 <h2 id="parameters">Parameters</h2>
 <dl>
-<dt><strong><code>amplitude</code></strong> :&ensp;<code>float</code> or {<code>"max"</code>, <code>"min"</code>}</dt>
+<dt><strong><code>amplitude</code></strong> :&ensp;<code>float</code> or <code>{"max", "min"}</code></dt>
 <dd>0.1mV or four digits resolution, "max" or "min" will set the
 amplitude to the maximum or minimum limit given in <code>channel_limits</code></dd>
 </dl>
 <h2 id="raises">Raises</h2>
 <dl>
-<dt><a title="tektronix_func_gen.NotSetError" href="#tektronix_func_gen.NotSetError"><code>NotSetError</code></a></dt>
-<dd>If <code>self.fgen.verify_param_set</code> is <code>True</code> and the value after
+<dt><code><a title="tektronix_func_gen.NotSetError" href="#tektronix_func_gen.NotSetError">NotSetError</a></code></dt>
+<dd>If <code>self._fgen.verify_param_set</code> is <code>True</code> and the value after
 applying the set function does not match the value returned by the
 get function</dd>
-</dl></section>
+</dl></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -3872,56 +3712,62 @@ get function</dd>
     Raises
     ------
     NotSetError
-        If `self.fgen.verify_param_set` is `True` and the value after
+        If `self._fgen.verify_param_set` is `True` and the value after
         applying the set function does not match the value returned by the
         get function
     &#34;&#34;&#34;
     # Check if keyword min or max is given
     if str(amplitude).lower() in [&#34;min&#34;, &#34;max&#34;]:
-        unit = &#34;&#34; # no unit for MIN/MAX
+        unit = &#34;&#34;  # no unit for MIN/MAX
         # Look up what the limit is for this keyword
-        amplitude = self.channel_limits[&#34;amplitude lims&#34;][0][self.impedance][str(amplitude).lower()]
+        amplitude = self.channel_limits[&#34;amplitude lims&#34;][0][self.impedance][
+            str(amplitude).lower()
+        ]
     else:
         unit = &#34;Vpp&#34;
         # Check if the given amplitude is within the current limits
         min_ampl, max_ampl = self.get_amplitude_lims()
         if amplitude &lt; min_ampl or amplitude &gt; max_ampl:
-            msg = (&#34;Could not set the amplitude {}{unit} as it is not &#34;
-                   &#34;within the amplitude limits set for the instrument &#34;
-                   &#34;[{}, {}]{unit}&#34;.format(amplitude, min_ampl, max_ampl,
-                                           unit=unit))
+            msg = (
+                f&#34;Could not set the amplitude {amplitude}{unit} as it &#34;
+                f&#34;is not within the amplitude limits set for the instrument &#34;
+                f&#34;[{min_ampl}, {max_ampl}]{unit}&#34;
+            )
             raise NotSetError(msg)
     # Check that the new amplitude will not violate voltage limits
     min_volt, max_volt = self.get_voltage_lims()
     current_offset = self.get_offset()
-    if (amplitude/2-current_offset &lt; min_volt or
-        amplitude/2+current_offset &gt; max_volt):
-        msg = (&#34;Could not set the amplitude {}{unit} as the amplitude &#34;
-               &#34;combined with the offset ({}V) will be outside the &#34;
-               &#34;absolute voltage limits [{}, {}]{unit}&#34;
-               &#34;&#34;.format(amplitude, current_offset, min_volt, max_volt,
-                         unit=unit))
+    if (
+        amplitude / 2 - current_offset &lt; min_volt
+        or amplitude / 2 + current_offset &gt; max_volt
+    ):
+        msg = (
+            f&#34;Could not set the amplitude {amplitude}{unit} as the amplitude &#34;
+            f&#34;combined with the offset ({current_offset}V) will be outside the &#34;
+            f&#34;absolute voltage limits [{min_volt}, {max_volt}]{unit}&#34;
+        )
         raise NotSetError(msg)
     # Set the amplitude
-    cmd = &#34;{}VOLTage:LEVel {}{}&#34;.format(self.source, amplitude, unit)
-    err_msg = &#34;set amplitude {}{}&#34;.format(amplitude, unit)
-    self.fgen.write(cmd, custom_err_message=err_msg)
+    cmd = f&#34;{self._source}VOLTage:LEVel {amplitude}{unit}&#34;
+    err_msg = f&#34;set amplitude {amplitude}{unit}&#34;
+    self._fgen.write(cmd, custom_err_message=err_msg)
     # Verify that the amplitude has been set
-    if self.fgen.verify_param_set:
+    if self._fgen.verify_param_set:
         actual_amplitude = self.get_amplitude()
         # Multiply with the appropriate factor according to SI prefix, or
         # if string is empty, use the value looked up from channel_limits earlier
         if not unit == &#34;&#34;:
-            check_amplitude = amplitude*self.SI_prefix_to_factor(unit)
+            check_amplitude = amplitude * _SI_prefix_to_factor(unit)
         else:
-             check_amplitude = amplitude
+            check_amplitude = amplitude
         if not actual_amplitude == check_amplitude:
-            msg = (&#34;Amplitude {}{} was not set on channel {}, it is &#34;
-                   &#34;{}Vpp. Check that the number is within the possible &#34;
-                   &#34;range and in the correct format.\nError from the &#34;
-                   &#34;instrument: {}&#34;
-                   &#34;&#34;.format(amplitude, unit, self.channel,
-                             actual_amplitude, self.fgen.get_error()))
+            msg = (
+                f&#34;Amplitude {amplitude}{unit} was not set on channel &#34;
+                f&#34;{self._channel}, it is {actual_amplitude}Vpp. Check that &#34;
+                f&#34; the number is within the possible range and in the &#34;
+                f&#34;correct format.\nError from the instrument: &#34;
+                f&#34;{self._fgen.get_error()}&#34;
+            )
             raise NotSetError(msg)</code></pre>
 </details>
 </dd>
@@ -3929,73 +3775,77 @@ get function</dd>
 <span>def <span class="ident">set_frequency</span></span>(<span>self, freq, unit='Hz')</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Set the frequency in Hertz (or kHz, MHz, see options)</p>
+<div class="desc"><p>Set the frequency in Hertz (or mHz, kHz, MHz, see options)</p>
 <h2 id="parameters">Parameters</h2>
 <dl>
 <dt><strong><code>freq</code></strong> :&ensp;<code>float</code></dt>
 <dd>The resolution is 1 μHz or 12 digits.</dd>
-<dt><strong><code>unit</code></strong> :&ensp;{<code>Hz</code>, <code>kHz</code>, <code>MHz</code>}, default <code>Hz</code></dt>
+<dt><strong><code>unit</code></strong> :&ensp;<code>{mHz, Hz, kHz, MHz}</code>, default <code>Hz</code></dt>
 <dd>&nbsp;</dd>
 </dl>
 <h2 id="raises">Raises</h2>
 <dl>
-<dt><a title="tektronix_func_gen.NotSetError" href="#tektronix_func_gen.NotSetError"><code>NotSetError</code></a></dt>
-<dd>If <code>self.fgen.verify_param_set</code> is <code>True</code> and the value after
+<dt><code><a title="tektronix_func_gen.NotSetError" href="#tektronix_func_gen.NotSetError">NotSetError</a></code></dt>
+<dd>If <code>self._fgen.verify_param_set</code> is <code>True</code> and the value after
 applying the set function does not match the value returned by the
 get function</dd>
-</dl></section>
+</dl></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">def set_frequency(self, freq, unit=&#34;Hz&#34;):
-    &#34;&#34;&#34;Set the frequency in Hertz (or kHz, MHz, see options)
+    &#34;&#34;&#34;Set the frequency in Hertz (or mHz, kHz, MHz, see options)
 
     Parameters
     ----------
     freq : float
         The resolution is 1 μHz or 12 digits.
-    unit : {Hz, kHz, MHz}, default Hz
+    unit : {mHz, Hz, kHz, MHz}, default Hz
 
     Raises
     ------
     NotSetError
-        If `self.fgen.verify_param_set` is `True` and the value after
+        If `self._fgen.verify_param_set` is `True` and the value after
         applying the set function does not match the value returned by the
         get function
     &#34;&#34;&#34;
-    if str(freq).lower() in [&#34;min&#34;, &#34;max&#34;]: # handle min and max keywords
-        unit = &#34;&#34; # no unit for MIN/MAX
+    if str(freq).lower() in [&#34;min&#34;, &#34;max&#34;]:  # handle min and max keywords
+        unit = &#34;&#34;  # no unit for MIN/MAX
         # Look up what the limit is for this keyword
         freq = self.channel_limits[&#34;frequency lims&#34;][0][str(freq).lower()]
     else:
         # Check if the given frequency is within the current limits
         min_freq, max_freq = self.get_frequency_lims()
+        freq = _SI_prefix_to_factor(unit) * freq
         if freq &lt; min_freq or freq &gt; max_freq:
-            msg = (&#34;Could not set the frequency {}{} as it is not within &#34;
-                   &#34;the frequency limits set for the instrument [{}, {}]&#34;
-                   &#34;Hz&#34;.format(freq, unit, min_freq, max_freq))
+            msg = (
+                f&#34;Could not set the frequency {freq}Hz as it is not &#34;
+                f&#34;within the frequency limits set for the instrument &#34;
+                f&#34;[{min_freq}, {max_freq}]Hz&#34;
+            )
             raise NotSetError(msg)
-    # Check that the new amplitude will not violate voltage limits
-    min_volt, max_volt = self.get_voltage_lims()
     # Set the frequency
-    self.fgen.write(&#34;{}FREQuency:FIXed {}{}&#34;.format(self.source, freq, unit),
-                        custom_err_message=&#34;set frequency {}{}&#34;.format(freq, unit))
+    self._fgen.write(
+        f&#34;{self._source}FREQuency:FIXed {freq}{unit}&#34;,
+        custom_err_message=f&#34;set frequency {freq}{unit}&#34;,
+    )
     # Verify that the amplitude has been set
-    if self.fgen.verify_param_set:
+    if self._fgen.verify_param_set:
         actual_freq = self.get_frequency()
         # Multiply with the appropriate factor according to SI prefix, or
         # if string is empty, use the value looked up from channel_limits earlier
         if not unit == &#34;&#34;:
-            check_freq = freq*self.SI_prefix_to_factor(unit)
+            check_freq = freq * _SI_prefix_to_factor(unit)
         else:
-            check_freq =  freq
+            check_freq = freq
         if not actual_freq == check_freq:
-            msg = (&#34;Frequency {}{} was not set on channel {}, it is {}Hz. &#34;
-            &#34;Check that the number is within the possible range and in &#34;
-            &#34;the correct format.\nError from the instrument: {}&#34;
-            &#34;&#34;.format(freq, unit, self.channel, actual_freq,
-                        self.fgen.get_error()))
+            msg = (
+                f&#34;Frequency {freq}{unit} was not set on channel {self._channel}&#34;
+                f&#34;, it is {actual_freq}Hz. Check that the number is within &#34;
+                f&#34;the possible range and in the correct format.\nError &#34;
+                f&#34;from the instrument: {self._fgen.get_error()}&#34;
+            )
             raise NotSetError(msg)</code></pre>
 </details>
 </dd>
@@ -4003,10 +3853,10 @@ get function</dd>
 <span>def <span class="ident">set_function</span></span>(<span>self, shape)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Set the function shape of the output</p>
+<div class="desc"><p>Set the function shape of the output</p>
 <h2 id="parameters">Parameters</h2>
 <dl>
-<dt><strong><code>shape</code></strong> :&ensp;{<code>SINusoid</code>, <code>SQUare</code>, <code>PULSe</code>, <code>RAMP</code>, <code>PRNoise</code>, &lt;<code>Built_in</code>&gt;, <code>USER</code>[<code>0</code>],</dt>
+<dt><strong><code>shape</code></strong> :&ensp;<code>{SINusoid, SQUare, PULSe, RAMP, PRNoise, &lt;Built_in&gt;, USER[0],</code></dt>
 <dd>USER1, &hellip;, USER255, EMEMory, EFILe}
 <Built_in>::={StairDown|StairUp|Stair Up&amp;Dwn|Trapezoid|RoundHalf|
 AbsSine|AbsHalfSine|ClippedSine|ChoppedSine|NegRamp|OscRise|
@@ -4018,11 +3868,11 @@ Cardiac}</dd>
 </dl>
 <h2 id="raises">Raises</h2>
 <dl>
-<dt><a title="tektronix_func_gen.NotSetError" href="#tektronix_func_gen.NotSetError"><code>NotSetError</code></a></dt>
-<dd>If <code>self.fgen.verify_param_set</code> is <code>True</code> and the value after
+<dt><code><a title="tektronix_func_gen.NotSetError" href="#tektronix_func_gen.NotSetError">NotSetError</a></code></dt>
+<dd>If <code>self._fgen.verify_param_set</code> is <code>True</code> and the value after
 applying the set function does not match the value returned by the
 get function</dd>
-</dl></section>
+</dl></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -4045,21 +3895,22 @@ get function</dd>
     Raises
     ------
     NotSetError
-        If `self.fgen.verify_param_set` is `True` and the value after
+        If `self._fgen.verify_param_set` is `True` and the value after
         applying the set function does not match the value returned by the
         get function
     &#34;&#34;&#34;
-    cmd = &#34;{}FUNCtion:SHAPe {}&#34;.format(self.source, shape)
-    self.fgen.write(cmd, custom_err_message=&#34;set function {}&#34;.format(shape))
-    if self.fgen.verify_param_set:
+    cmd = f&#34;{self._source}FUNCtion:SHAPe {shape}&#34;
+    self._fgen.write(cmd, custom_err_message=f&#34;set function {shape}&#34;)
+    if self._fgen.verify_param_set:
         actual_shape = self.get_function()
         if not actual_shape == shape:
-            msg = (&#34;Function {} was not set on channel {}, it is {}. &#34;
-                   &#34;Check that the function name is correctly spelt. &#34;
-                   &#34;Run set_function.__doc__ to see available shapes.\n&#34;
-                   &#34;Error from the instrument: {}&#34;
-                   &#34;&#34;.format(shape, self.channel, actual_shape,
-                             self.fgen.get_error()))
+            msg = (
+                f&#34;Function {shape} was not set on channel {self._channel}, &#34;
+                f&#34;it is {actual_shape}. Check that the function name is &#34;
+                f&#34;correctly spelt. Look up `set_function.__doc__` to see &#34;
+                f&#34;available shapes.\n Error from the instrument: &#34;
+                f&#34;{self._fgen.get_error()}&#34;
+            )
             raise NotSetError(msg)</code></pre>
 </details>
 </dd>
@@ -4067,25 +3918,23 @@ get function</dd>
 <span>def <span class="ident">set_limit</span></span>(<span>self, limit_type, bound, new_value, verbose=False)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Set a limit if the new value is within the instrument limits and are
+<div class="desc"><p>Set a limit if the new value is within the instrument limits and are
 self consistent (max larger than min)</p>
 <h2 id="parameterers">Parameterers</h2>
-<dl>
-<dt><strong><code>limit_type</code></strong> :&ensp;<code>str</code></dt>
-<dd>The name of the limit in the channel_limits dictionary</dd>
-<dt><strong><code>bound</code></strong> :&ensp;{<code>"min"</code>, <code>"max"</code>}</dt>
-<dd>Specifies if it is the max or the min limit that is to be set</dd>
-<dt><strong><code>new_value</code></strong> :&ensp;<code>float</code></dt>
-<dd>The new value to be used for the limit</dd>
-<dt><strong><code>verbose</code></strong> :&ensp;<code>bool</code></dt>
-<dd>Print confirmation that the limit was set or reason for why the
-limit was not set</dd>
-</dl>
+<p>limit_type : str
+The name of the limit in the channel_limits dictionary
+bound : {"min", "max"}
+Specifies if it is the max or the min limit that is to be set
+new_value : float
+The new value to be used for the limit
+verbose : bool
+Print confirmation that the limit was set or reason for why the
+limit was not set</p>
 <h2 id="returns">Returns</h2>
 <dl>
 <dt><code>bool</code></dt>
 <dd><code>True</code> if new limit set, <code>False</code> otherwise</dd>
-</dl></section>
+</dl></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -4112,10 +3961,10 @@ limit was not set</dd>
         `True` if new limit set, `False` otherwise
     &#34;&#34;&#34;
     # Short hand references
-    inst_limit_dict = self.fgen.instrument_limits[limit_type]
+    inst_limit_dict = self._fgen.instrument_limits[limit_type]
     channel_limit_dict = self.channel_limits[limit_type]
     # Find the instrument limit and unit
-    use_impedance = self.impedance_dependent_limit(limit_type)
+    use_impedance = self._impedance_dependent_limit(limit_type)
     if use_impedance:
         inst_value = inst_limit_dict[0][self.impedance][bound]
     else:
@@ -4129,7 +3978,7 @@ limit was not set</dd>
         current_min = channel_limit_dict[0][&#34;min&#34;]
     larger_than_min = new_value &gt; current_min
     acceptable_max = bound == &#34;max&#34; and new_value &lt; inst_value and larger_than_min
-    if acceptable_min or acceptable_max: # within the limits
+    if acceptable_min or acceptable_max:  # within the limits
         # Set the new channel_limit, using the impedance depending on the
         # limit type. Beware that the shorthand cannot be used, as this
         # only changes the shorthand not the dictionary itself
@@ -4138,19 +3987,20 @@ limit was not set</dd>
         else:
             self.channel_limits[limit_type][0][bound] = new_value
         if verbose:
-            print(&#34;\tNew limit set {}{}&#34;.format(new_value, unit))
+            print(f&#34;\tNew limit set {new_value}{unit}&#34;)
         return True
-    elif verbose: # print description of why the limit was not set
+    if verbose:  # print description of why the limit was not set
         if larger_than_min:
             reason = &#34;larger&#34; if bound == &#34;max&#34; else &#34;smaller&#34;
-            print(&#34;\tNew limit NOT set: {}{unit} is {} than the instrument &#34;
-                  &#34;limit ({}{unit})&#34;.format(new_value, reason, inst_value,
-                                            unit=unit))
+            print(
+                f&#34;\tNew limit NOT set: {new_value}{unit} is {reason} than &#34;
+                f&#34;the instrument limit ({inst_value}{unit})&#34;
+            )
         else:
-            print(&#34;\tNew limit NOT set: {}{unit} is smaller than the &#34;
-                  &#34;current set minimum ({}{unit})&#34;.format(new_value,
-                                                          current_min,
-                                                          unit=unit))
+            print(
+                f&#34;\tNew limit NOT set: {new_value}{unit} is smaller than the &#34;
+                f&#34;current set minimum ({current_min}{unit})&#34;
+            )
     return False</code></pre>
 </details>
 </dd>
@@ -4158,21 +4008,21 @@ limit was not set</dd>
 <span>def <span class="ident">set_offset</span></span>(<span>self, offset, unit='V')</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Set offset in volts (or mV, see options)</p>
+<div class="desc"><p>Set offset in volts (or mV, see options)</p>
 <h2 id="parameters">Parameters</h2>
 <dl>
 <dt><strong><code>offset</code></strong> :&ensp;<code>float</code></dt>
 <dd>Unknown resolution, guessing 0.1mV or four digits resolution</dd>
-<dt><strong><code>unit</code></strong> :&ensp;{<code>mV</code>, <code>V</code>}, default <code>V</code></dt>
+<dt><strong><code>unit</code></strong> :&ensp;<code>{mV, V}</code>, default <code>V</code></dt>
 <dd>&nbsp;</dd>
 </dl>
 <h2 id="raises">Raises</h2>
 <dl>
-<dt><a title="tektronix_func_gen.NotSetError" href="#tektronix_func_gen.NotSetError"><code>NotSetError</code></a></dt>
-<dd>If <code>self.fgen.verify_param_set</code> is <code>True</code> and the value after
+<dt><code><a title="tektronix_func_gen.NotSetError" href="#tektronix_func_gen.NotSetError">NotSetError</a></code></dt>
+<dd>If <code>self._fgen.verify_param_set</code> is <code>True</code> and the value after
 applying the set function does not match the value returned by the
 get function</dd>
-</dl></section>
+</dl></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -4189,37 +4039,40 @@ get function</dd>
     Raises
     ------
     NotSetError
-        If `self.fgen.verify_param_set` is `True` and the value after
+        If `self._fgen.verify_param_set` is `True` and the value after
         applying the set function does not match the value returned by the
         get function
     &#34;&#34;&#34;
     # Check that the new offset will not violate voltage limits
     min_volt, max_volt = self.get_voltage_lims()
     current_amplitude = self.get_amplitude()
-    if (current_amplitude/2-offset &lt; min_volt or
-        current_amplitude/2+offset &gt; max_volt):
-        msg = (&#34;Could not set the offset {}{unit} as the offset combined&#34;
-               &#34;with the amplitude ({}V) will be outside the absolute &#34;
-               &#34;voltage limits [{}, {}]{unit}&#34;.format(offset,
-                                                     current_amplitude,
-                                                     min_volt, max_volt,
-                                                     unit=unit))
+    offset = _SI_prefix_to_factor(unit) * offset
+    if (
+        current_amplitude / 2 - offset &lt; min_volt
+        or current_amplitude / 2 + offset &gt; max_volt
+    ):
+        msg = (
+            f&#34;Could not set the offset {offset}V as the offset combined &#34;
+            f&#34;with the amplitude ({current_amplitude}V) will be outside &#34;
+            f&#34;the absolute voltage limits [{min_volt}, {max_volt}]V&#34;
+        )
         raise NotSetError(msg)
     # Set the offset
-    cmd = &#34;{}VOLTage:LEVel:OFFSet {}{}&#34;.format(self.source, offset, unit)
-    err_msg = &#34;set offset {}{}&#34;.format(offset, unit)
-    self.fgen.write(cmd, custom_err_message=err_msg)
+    cmd = f&#34;{self._source}VOLTage:LEVel:OFFSet {offset}{unit}&#34;
+    err_msg = f&#34;set offset {offset}{unit}&#34;
+    self._fgen.write(cmd, custom_err_message=err_msg)
     # Verify that the offset has been set
-    if self.fgen.verify_param_set:
+    if self._fgen.verify_param_set:
         actual_offset = self.get_offset()
         # Multiply with the appropriate factor according to SI prefix
-        check_offset = offset*self.SI_prefix_to_factor(unit)
+        check_offset = offset * _SI_prefix_to_factor(unit)
         if not actual_offset == check_offset:
-            msg = (&#34;Offset {}{} was not set on channel {}, it is {}V. &#34;
-                   &#34;Check that the number is within the possible range and &#34;
-                   &#34;in the correct format.\nError from the instrument: {}&#34;
-                   &#34;&#34;.format(offset, unit, self.channel, actual_offset,
-                             self.fgen.get_error()))
+            msg = (
+                f&#34;Offset {offset}{unit} was not set on channel &#34;
+                f&#34;{self._channel}, it is {actual_offset}V. Check that the &#34;
+                f&#34;number is within the possible range and in the correct &#34;
+                f&#34;format.\nError from the instrument: {self._fgen.get_error()}&#34;
+            )
             raise NotSetError(msg)</code></pre>
 </details>
 </dd>
@@ -4227,7 +4080,7 @@ get function</dd>
 <span>def <span class="ident">set_output</span></span>(<span>self, state)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Wrapper for set_output_state</p></section>
+<div class="desc"><p>Wrapper for set_output_state</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -4241,7 +4094,7 @@ get function</dd>
 <span>def <span class="ident">set_output_state</span></span>(<span>self, state)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Enables or diables the output of the channel</p>
+<div class="desc"><p>Enables or diables the output of the channel</p>
 <h2 id="parameters">Parameters</h2>
 <dl>
 <dt><strong><code>state</code></strong> :&ensp;<code>int</code> or <code>str</code></dt>
@@ -4250,11 +4103,11 @@ get function</dd>
 </dl>
 <h2 id="raises">Raises</h2>
 <dl>
-<dt><a title="tektronix_func_gen.NotSetError" href="#tektronix_func_gen.NotSetError"><code>NotSetError</code></a></dt>
-<dd>If <code>self.fgen.verify_param_set</code> is <code>True</code> and the value after
+<dt><code><a title="tektronix_func_gen.NotSetError" href="#tektronix_func_gen.NotSetError">NotSetError</a></code></dt>
+<dd>If <code>self._fgen.verify_param_set</code> is <code>True</code> and the value after
 applying the set function does not match the value returned by the
 get function</dd>
-</dl></section>
+</dl></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -4271,21 +4124,22 @@ get function</dd>
     Raises
     ------
     NotSetError
-        If `self.fgen.verify_param_set` is `True` and the value after
+        If `self._fgen.verify_param_set` is `True` and the value after
         applying the set function does not match the value returned by the
         get function
     &#34;&#34;&#34;
-    err_msg = &#34;turn channel {} to state {}&#34;.format(self.channel, state)
-    self.fgen.write(&#34;OUTPut{}:STATe {}&#34;.format(self.channel, state),
-                                        custom_err_message=err_msg)
-    if self.fgen.verify_param_set:
+    err_msg = f&#34;turn channel {self._channel} to state {state}&#34;
+    self._fgen.write(
+        f&#34;OUTPut{self._channel}:STATe {state}&#34;, custom_err_message=err_msg
+    )
+    if self._fgen.verify_param_set:
         actual_state = self.get_output_state()
         if not actual_state == state:
-            msg = (&#34;Channel {} was not turned {}, it is {}.\n&#34;
-                   &#34;Error from the instrument: {}&#34;
-                   &#34;&#34;.format(self.channel, state,
-                             self.state_str[actual_state],
-                             self.fgen.get_error()))
+            msg = (
+                f&#34;Channel {self._channel} was not turned {state}, it is &#34;
+                f&#34;{self._state_to_str[actual_state]}.\n&#34;
+                f&#34;Error from the instrument: {self._fgen.get_error()}&#34;
+            )
             raise NotSetError(msg)</code></pre>
 </details>
 </dd>
@@ -4293,15 +4147,13 @@ get function</dd>
 <span>def <span class="ident">set_settings</span></span>(<span>self, settings)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Set the settings of the channel with a settings dictionary. Will
+<div class="desc"><p>Set the settings of the channel with a settings dictionary. Will
 set the outout to OFF before applyign the settings (and turn the
 channel ON or leave it OFF depending on the settings dict)</p>
 <h2 id="parameteres">Parameteres</h2>
-<dl>
-<dt><strong><code>settings</code></strong> :&ensp;<code>dict</code></dt>
-<dd>Settings dictionary as returned by <code>get_settings</code>: should have
-keys output, function, amplitude, offset, and frequency</dd>
-</dl></section>
+<p>settings : dict
+Settings dictionary as returned by <code>get_settings</code>: should have
+keys output, function, amplitude, offset, and frequency</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -4321,19 +4173,19 @@ keys output, function, amplitude, offset, and frequency</dd>
     # combination of settings
     self.set_output_state(&#34;OFF&#34;)
     # Set settings according to dictionary
-    self.set_function(settings[&#39;function&#39;][0])
-    self.set_amplitude(settings[&#39;amplitude&#39;][0])
-    self.set_offset(settings[&#39;offset&#39;][0])
-    self.set_frequency(settings[&#39;frequency&#39;][0])
-    self.set_output_state(settings[&#39;output&#39;][0])</code></pre>
+    self.set_function(settings[&#34;function&#34;][0])
+    self.set_amplitude(settings[&#34;amplitude&#34;][0])
+    self.set_offset(settings[&#34;offset&#34;][0])
+    self.set_frequency(settings[&#34;frequency&#34;][0])
+    self.set_output_state(settings[&#34;output&#34;][0])</code></pre>
 </details>
 </dd>
 <dt id="tektronix_func_gen.FuncGenChannel.set_stricter_limits"><code class="name flex">
 <span>def <span class="ident">set_stricter_limits</span></span>(<span>self)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Set limits for the voltage and frequency limits of the channel output
-through a series of prompts</p></section>
+<div class="desc"><p>Set limits for the voltage and frequency limits of the channel output
+through a series of prompts</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -4341,33 +4193,33 @@ through a series of prompts</p></section>
 <pre><code class="python">def set_stricter_limits(self):
     &#34;&#34;&#34;Set limits for the voltage and frequency limits of the channel output
     through a series of prompts&#34;&#34;&#34;
-    print(&#34;Set stricter voltage and frequency limits &#34;
-          &#34;for channel {}&#34;.format(self.channel))
+    print(f&#34;Set stricter voltage and frequency limits for channel {self._channel}&#34;)
     print(&#34;Use enter only to leave a limit unchanged.&#34;)
     # Go through the different limits in the instrument_limits dict
-    for limit_type, (inst_limit_dict, unit) in self.fgen.instrument_limits.items():
-        use_impedance = self.impedance_dependent_limit(limit_type)
-        print(&#34;Set {} in {}&#34;.format(limit_type, unit), end=&#34; &#34;)
+    for limit_type, (inst_limit_dict, unit) in self._fgen.instrument_limits.items():
+        use_impedance = self._impedance_dependent_limit(limit_type)
+        print(f&#34;Set {limit_type} in {unit}&#34;, end=&#34; &#34;)
         if use_impedance:
             inst_limit_dict = inst_limit_dict[self.impedance]
-            print(&#34;[{} impedance limit]&#34;.format(self.impedance))
+            print(f&#34;[{self.impedance} impedance limit]&#34;)
         else:
-            print(&#34;&#34;) # get new line
+            print(&#34;&#34;)  # get new line
         # Go through the min and max for the limit type
         for key, inst_value in inst_limit_dict.items():
             # prompt for new value
-            new_value = input(&#34;  {} (instrument limit {}{}): &#34;
-                              &#34;&#34;.format(key, inst_value, unit))
+            new_value = input(f&#34;  {key} (instrument limit {inst_value}{unit}): &#34;)
             if new_value == &#34;&#34;:
                 # Do not change if empty
                 print(&#34;\tLimit not changed&#34;)
             else:
-                try: # to convert to float
+                try:  # to convert to float
                     new_value = float(new_value)
                 except ValueError:
-                    print(&#34;\tLimit unchanged: Could not convert \&#39;{}\&#39; &#34;
-                          &#34;to float&#34;.format(new_value))
-                    continue # to next item in dict
+                    print(
+                        f&#34;\tLimit unchanged: Could not convert &#39;{new_value}&#39; &#34;
+                        f&#34;to float&#34;
+                    )
+                    continue  # to next item in dict
                 # Set the new limit
                 self.set_limit(limit_type, key, new_value, verbose=True)</code></pre>
 </details>
@@ -4376,10 +4228,10 @@ through a series of prompts</p></section>
 </dd>
 <dt id="tektronix_func_gen.NotCompatibleError"><code class="flex name class">
 <span>class <span class="ident">NotCompatibleError</span></span>
-<span>(</span><span>...)</span>
+<span>(</span><span>*args, **kwargs)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Error for when the instrument is not compatible with this module</p></section>
+<div class="desc"><p>Error for when the instrument is not compatible with this module</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -4395,10 +4247,10 @@ through a series of prompts</p></section>
 </dd>
 <dt id="tektronix_func_gen.NotSetError"><code class="flex name class">
 <span>class <span class="ident">NotSetError</span></span>
-<span>(</span><span>...)</span>
+<span>(</span><span>*args, **kwargs)</span>
 </code></dt>
 <dd>
-<section class="desc"><p>Error for when a value cannot be written to the instrument</p></section>
+<div class="desc"><p>Error for when a value cannot be written to the instrument</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -4419,7 +4271,21 @@ through a series of prompts</p></section>
 <h1>Index</h1>
 <div class="toc">
 <ul>
-<li><a href="#tektronix-arbitrary-function-generator-control-through-pyvisa">Tektronix arbitrary function generator control through PyVISA</a></li>
+<li><a href="#tektronix-arbitrary-function-generator-control">Tektronix arbitrary function generator control</a><ul>
+<li><a href="#known-issues">Known issues</a></li>
+<li><a href="#installation">Installation</a></li>
+<li><a href="#usage-through-examples">Usage (through examples)</a><ul>
+<li><a href="#syncronisation-and-frequency-lock">Syncronisation and frequency lock</a></li>
+<li><a href="#arbitrary-waveforms">Arbitrary waveforms</a><ul>
+<li><a href="#flat-function-offset-control">Flat function offset control</a></li>
+</ul>
+</li>
+<li><a href="#set-voltage-and-frequency-limits">Set voltage and frequency limits</a></li>
+<li><a href="#impedance">Impedance</a></li>
+</ul>
+</li>
+</ul>
+</li>
 </ul>
 </div>
 <ul id="index">
@@ -4437,33 +4303,32 @@ through a series of prompts</p></section>
 <li>
 <h4><code><a title="tektronix_func_gen.FuncGen" href="#tektronix_func_gen.FuncGen">FuncGen</a></code></h4>
 <ul class="">
-<li><code><a title="tektronix_func_gen.FuncGen.check_arb_waveform_length" href="#tektronix_func_gen.FuncGen.check_arb_waveform_length">check_arb_waveform_length</a></code></li>
-<li><code><a title="tektronix_func_gen.FuncGen.check_arb_waveform_type_and_range" href="#tektronix_func_gen.FuncGen.check_arb_waveform_type_and_range">check_arb_waveform_type_and_range</a></code></li>
-<li><code><a title="tektronix_func_gen.FuncGen.check_pyvisa_status" href="#tektronix_func_gen.FuncGen.check_pyvisa_status">check_pyvisa_status</a></code></li>
+<li><code><a title="tektronix_func_gen.FuncGen.ch1" href="#tektronix_func_gen.FuncGen.ch1">ch1</a></code></li>
+<li><code><a title="tektronix_func_gen.FuncGen.ch2" href="#tektronix_func_gen.FuncGen.ch2">ch2</a></code></li>
+<li><code><a title="tektronix_func_gen.FuncGen.channels" href="#tektronix_func_gen.FuncGen.channels">channels</a></code></li>
 <li><code><a title="tektronix_func_gen.FuncGen.close" href="#tektronix_func_gen.FuncGen.close">close</a></code></li>
 <li><code><a title="tektronix_func_gen.FuncGen.get_custom_waveform" href="#tektronix_func_gen.FuncGen.get_custom_waveform">get_custom_waveform</a></code></li>
 <li><code><a title="tektronix_func_gen.FuncGen.get_error" href="#tektronix_func_gen.FuncGen.get_error">get_error</a></code></li>
 <li><code><a title="tektronix_func_gen.FuncGen.get_frequency_lock" href="#tektronix_func_gen.FuncGen.get_frequency_lock">get_frequency_lock</a></code></li>
 <li><code><a title="tektronix_func_gen.FuncGen.get_settings" href="#tektronix_func_gen.FuncGen.get_settings">get_settings</a></code></li>
 <li><code><a title="tektronix_func_gen.FuncGen.get_waveform_catalogue" href="#tektronix_func_gen.FuncGen.get_waveform_catalogue">get_waveform_catalogue</a></code></li>
-<li><code><a title="tektronix_func_gen.FuncGen.initialise_model_properties" href="#tektronix_func_gen.FuncGen.initialise_model_properties">initialise_model_properties</a></code></li>
-<li><code><a title="tektronix_func_gen.FuncGen.normalise_to_waveform" href="#tektronix_func_gen.FuncGen.normalise_to_waveform">normalise_to_waveform</a></code></li>
+<li><code><a title="tektronix_func_gen.FuncGen.instrument_limits" href="#tektronix_func_gen.FuncGen.instrument_limits">instrument_limits</a></code></li>
 <li><code><a title="tektronix_func_gen.FuncGen.print_settings" href="#tektronix_func_gen.FuncGen.print_settings">print_settings</a></code></li>
 <li><code><a title="tektronix_func_gen.FuncGen.query" href="#tektronix_func_gen.FuncGen.query">query</a></code></li>
 <li><code><a title="tektronix_func_gen.FuncGen.set_custom_waveform" href="#tektronix_func_gen.FuncGen.set_custom_waveform">set_custom_waveform</a></code></li>
 <li><code><a title="tektronix_func_gen.FuncGen.set_frequency_lock" href="#tektronix_func_gen.FuncGen.set_frequency_lock">set_frequency_lock</a></code></li>
 <li><code><a title="tektronix_func_gen.FuncGen.set_settings" href="#tektronix_func_gen.FuncGen.set_settings">set_settings</a></code></li>
 <li><code><a title="tektronix_func_gen.FuncGen.software_trig" href="#tektronix_func_gen.FuncGen.software_trig">software_trig</a></code></li>
-<li><code><a title="tektronix_func_gen.FuncGen.spawn_channel" href="#tektronix_func_gen.FuncGen.spawn_channel">spawn_channel</a></code></li>
 <li><code><a title="tektronix_func_gen.FuncGen.syncronise_waveforms" href="#tektronix_func_gen.FuncGen.syncronise_waveforms">syncronise_waveforms</a></code></li>
-<li><code><a title="tektronix_func_gen.FuncGen.verify_waveform" href="#tektronix_func_gen.FuncGen.verify_waveform">verify_waveform</a></code></li>
+<li><code><a title="tektronix_func_gen.FuncGen.verbose" href="#tektronix_func_gen.FuncGen.verbose">verbose</a></code></li>
+<li><code><a title="tektronix_func_gen.FuncGen.verify_param_set" href="#tektronix_func_gen.FuncGen.verify_param_set">verify_param_set</a></code></li>
 <li><code><a title="tektronix_func_gen.FuncGen.write" href="#tektronix_func_gen.FuncGen.write">write</a></code></li>
 </ul>
 </li>
 <li>
 <h4><code><a title="tektronix_func_gen.FuncGenChannel" href="#tektronix_func_gen.FuncGenChannel">FuncGenChannel</a></code></h4>
-<ul class="">
-<li><code><a title="tektronix_func_gen.FuncGenChannel.SI_prefix_to_factor" href="#tektronix_func_gen.FuncGenChannel.SI_prefix_to_factor">SI_prefix_to_factor</a></code></li>
+<ul class="two-column">
+<li><code><a title="tektronix_func_gen.FuncGenChannel.channel_limits" href="#tektronix_func_gen.FuncGenChannel.channel_limits">channel_limits</a></code></li>
 <li><code><a title="tektronix_func_gen.FuncGenChannel.get_amplitude" href="#tektronix_func_gen.FuncGenChannel.get_amplitude">get_amplitude</a></code></li>
 <li><code><a title="tektronix_func_gen.FuncGenChannel.get_amplitude_lims" href="#tektronix_func_gen.FuncGenChannel.get_amplitude_lims">get_amplitude_lims</a></code></li>
 <li><code><a title="tektronix_func_gen.FuncGenChannel.get_frequency" href="#tektronix_func_gen.FuncGenChannel.get_frequency">get_frequency</a></code></li>
@@ -4474,7 +4339,7 @@ through a series of prompts</p></section>
 <li><code><a title="tektronix_func_gen.FuncGenChannel.get_output_state" href="#tektronix_func_gen.FuncGenChannel.get_output_state">get_output_state</a></code></li>
 <li><code><a title="tektronix_func_gen.FuncGenChannel.get_settings" href="#tektronix_func_gen.FuncGenChannel.get_settings">get_settings</a></code></li>
 <li><code><a title="tektronix_func_gen.FuncGenChannel.get_voltage_lims" href="#tektronix_func_gen.FuncGenChannel.get_voltage_lims">get_voltage_lims</a></code></li>
-<li><code><a title="tektronix_func_gen.FuncGenChannel.impedance_dependent_limit" href="#tektronix_func_gen.FuncGenChannel.impedance_dependent_limit">impedance_dependent_limit</a></code></li>
+<li><code><a title="tektronix_func_gen.FuncGenChannel.impedance" href="#tektronix_func_gen.FuncGenChannel.impedance">impedance</a></code></li>
 <li><code><a title="tektronix_func_gen.FuncGenChannel.print_settings" href="#tektronix_func_gen.FuncGenChannel.print_settings">print_settings</a></code></li>
 <li><code><a title="tektronix_func_gen.FuncGenChannel.set_amplitude" href="#tektronix_func_gen.FuncGenChannel.set_amplitude">set_amplitude</a></code></li>
 <li><code><a title="tektronix_func_gen.FuncGenChannel.set_frequency" href="#tektronix_func_gen.FuncGenChannel.set_frequency">set_frequency</a></code></li>
@@ -4485,7 +4350,6 @@ through a series of prompts</p></section>
 <li><code><a title="tektronix_func_gen.FuncGenChannel.set_output_state" href="#tektronix_func_gen.FuncGenChannel.set_output_state">set_output_state</a></code></li>
 <li><code><a title="tektronix_func_gen.FuncGenChannel.set_settings" href="#tektronix_func_gen.FuncGenChannel.set_settings">set_settings</a></code></li>
 <li><code><a title="tektronix_func_gen.FuncGenChannel.set_stricter_limits" href="#tektronix_func_gen.FuncGenChannel.set_stricter_limits">set_stricter_limits</a></code></li>
-<li><code><a title="tektronix_func_gen.FuncGenChannel.state_str" href="#tektronix_func_gen.FuncGenChannel.state_str">state_str</a></code></li>
 </ul>
 </li>
 <li>
@@ -4500,9 +4364,7 @@ through a series of prompts</p></section>
 </nav>
 </main>
 <footer id="footer">
-<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.7.5</a>.</p>
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2</a>.</p>
 </footer>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
-<script>hljs.initHighlightingOnLoad()</script>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -23,6 +23,8 @@
 </header>
 <section id="section-intro">
 <h2 id="tektronix-arbitrary-function-generator-control">Tektronix arbitrary function generator control</h2>
+<p><a href="https://www.codefactor.io/repository/github/asvela/tektronix-func-gen"><img alt="CodeFactor Grade" src="https://img.shields.io/codefactor/grade/github/asvela/tektronix-func-gen?style=flat-square"></a>
+<a href="https://github.com/asvela/dlc-control/blob/main/LICENSE"><img alt="MIT License" src="https://img.shields.io/github/license/asvela/dlc-control?style=flat-square"></a></p>
 <p>API documentation available <a href="https://asvela.github.io/tektronix-func-gen/">here</a>,
 or in the repository <a href="docs/index.html">docs/index.html</a>. (To build the documentation
 yourself use <a href="https://pdoc3.github.io/pdoc/">pdoc3</a> and run

--- a/tektronix_func_gen.py
+++ b/tektronix_func_gen.py
@@ -26,15 +26,19 @@ import pyvisa
 import numpy as np
 
 
+_VISA_ADDRESS = "USB0::0x0699::0x0353::1731975::INSTR"
+
+
 ## ~~~~~~~~~~~~~~~~~~~~~ FUNCTION GENERATOR CLASS ~~~~~~~~~~~~~~~~~~~~~~~~~~ ##
 
-class FuncGen():
+
+class FuncGen:
     """Class for interacting with Tektronix function generator
 
     Parameters
     ----------
-    address : str
-        VISA address of insrument
+    visa_address : str
+        VISA address of the insrument
     impedance : tuple of {"highZ", "50ohm"}, default ("highZ",)*2
         Determines voltage limits associated with high impedance (whether the
         instrument is using 50ohm or high Z cannot be controlled through VISA).
@@ -54,12 +58,12 @@ class FuncGen():
 
     Attributes
     ----------
-    address : str
+    _visa_address : str
         The VISA address of the instrument
-    id : str
+    _id : str
         Comma separated string with maker, model, serial and firmware of
         the instrument
-    inst : `pyvisa.resources.Resource`
+    _inst : `pyvisa.resources.Resource`
         The PyVISA resource
     channels : tuple of FuncGenChannel
         Objects to control the channels
@@ -80,10 +84,14 @@ class FuncGen():
             Contains the smallest and largest possible amplitudes where the
             keys "50ohm" and "highZ" will have subdictionaries with keys
             "min" and "max"
-    arbitrary_waveform_length : list
+    verify_param_set : bool
+        Verify that a value is successfully set after executing a set function
+    verbose : bool
+        Choose whether to print information such as model upon connecting etc
+    _arbitrary_waveform_length : list
         The permitted minimum and maximum length of an arbitrary waveform,
         e.g. [2, 8192]
-    arbitrary_waveform_resolution : int
+    _arbitrary_waveform_resolution : int
         The vertical resolution of the arbitrary waveform, for instance 14 bit
         => 2**14-1 = 16383
 
@@ -97,37 +105,47 @@ class FuncGen():
         use AFG1022 limits)
     """
 
-    def __init__(self, address, impedance=("highZ",)*2, timeout=5000,
-                 verify_param_set=False, override_compatibility=False,
-                 verbose=True):
-        self.override_compatibility = override_compatibility
-        self.address = address
-        self.timeout = timeout
+    def __init__(
+        self,
+        visa_address,
+        impedance=("highZ",) * 2,
+        timeout=5000,
+        verify_param_set=False,
+        override_compatibility=False,
+        verbose=True,
+    ):
+        self._override_compatibility = override_compatibility
+        self._visa_address = visa_address
+        self._timeout = timeout
         self.verify_param_set = verify_param_set
         self.verbose = verbose
         try:
             rm = pyvisa.ResourceManager()
-            self.inst = rm.open_resource(address)
+            self._inst = rm.open_resource(visa_address)
         except pyvisa.Error:
-            print("\nVisaError: Could not connect to \'{}\'".format(address))
+            print(f"\nVisaError: Could not connect to '{visa_address}'")
             raise
-        self.inst.timeout = self.timeout
+        self._inst.timeout = self._timeout
         # Clear all the event registers and queues used in the instrument
         # status and event reporting system
         self.write("*CLS")
         # Get information about the connected device
-        self.id = self.query("*IDN?")
+        self._id = self.query("*IDN?")
         # Second query might be needed due to unknown reason
         # (suspecting *CLS does something weird)
-        if self.id == '':
-            self.id = self.query("*IDN?")
-        self.maker, self.model, self.serial = self.id.split(",")[:3]
+        if self._id == "":
+            self._id = self.query("*IDN?")
+        self._maker, self._model, self._serial = self._id.split(",")[:3]
         if self.verbose:
-            print("Connected to {} model {}, serial"
-                  " {}".format(self.maker, self.model, self.serial))
-        self.initialise_model_properties()
-        self.channels = (self.spawn_channel(1, impedance[0]),
-                         self.spawn_channel(2, impedance[1]))
+            print(
+                "Connected to {} model {}, serial"
+                " {}".format(self._maker, self._model, self._serial)
+            )
+        self._initialise_model_properties()
+        self.channels = (
+            self._spawn_channel(1, impedance[0]),
+            self._spawn_channel(2, impedance[1]),
+        )
         self.ch1, self.ch2 = self.channels
 
     def __enter__(self, **kwargs):
@@ -142,9 +160,9 @@ class FuncGen():
 
     def close(self):
         """Close the connection to the instrument"""
-        self.inst.close()
+        self._inst.close()
 
-    def initialise_model_properties(self):
+    def _initialise_model_properties(self):
         """Initialises the limits of what the instrument can handle according
         to the instrument model
 
@@ -154,21 +172,31 @@ class FuncGen():
             If the connected model is not necessarily compatible with this
             package, slimits are not known.
         """
-        if self.model == 'AFG1022' or self.override_compatibility:
+        if self._model == "AFG1022" or self._override_compatibility:
             self.instrument_limits = {
                 "frequency lims": ({"min": 1e-6, "max": 25e6}, "Hz"),
-                "voltage lims":   ({"50ohm": {"min": -5, "max": 5},
-                                    "highZ": {"min": -10, "max": 10}}, "V"),
-                "amplitude lims": ({"50ohm": {"min": 0.001, "max": 10},
-                                    "highZ": {"min": 0.002, "max": 20}}, "Vpp")}
-            self.arbitrary_waveform_length = [2, 8192]  # min length, max length
-            self.arbitrary_waveform_resolution = 16383  # 14 bit
+                "voltage lims": (
+                    {"50ohm": {"min": -5, "max": 5}, "highZ": {"min": -10, "max": 10}},
+                    "V",
+                ),
+                "amplitude lims": (
+                    {
+                        "50ohm": {"min": 0.001, "max": 10},
+                        "highZ": {"min": 0.002, "max": 20},
+                    },
+                    "Vpp",
+                ),
+            }
+            self._arbitrary_waveform_length = [2, 8192]  # min length, max length
+            self._arbitrary_waveform_resolution = 16383  # 14 bit
         else:
-            msg = ("Model {} not supported, no limits set!"
-                   "\n\tTo use the limits for AFG1022, call the class with "
-                   "'override_compatibility=True'"
-                   "\n\tNote that this might lead to unexpected behaviour "
-                   "for custom waveforms and 'MIN'/'MAX' keywords.")
+            msg = (
+                "Model {} not supported, no limits set!"
+                "\n\tTo use the limits for AFG1022, call the class with "
+                "'override_compatibility=True'"
+                "\n\tNote that this might lead to unexpected behaviour "
+                "for custom waveforms and 'MIN'/'MAX' keywords."
+            )
             raise NotCompatibleError(msg)
 
     def write(self, command, custom_err_message=None):
@@ -195,8 +223,8 @@ class FuncGen():
             If status returned by PyVISA write command is not
             `pyvisa.constants.StatusCode.success`
         """
-        num_bytes = self.inst.write(command)
-        self.check_pyvisa_status(command, custom_err_message=custom_err_message)
+        num_bytes = self._inst.write(command)
+        self._check_pyvisa_status(command, custom_err_message=custom_err_message)
         return num_bytes
 
     def query(self, command, custom_err_message=None):
@@ -223,11 +251,11 @@ class FuncGen():
             If status returned by PyVISA write command is not
             `pyvisa.constants.StatusCode.success`
         """
-        response = self.inst.query(command).strip()
-        self.check_pyvisa_status(command, custom_err_message=custom_err_message)
+        response = self._inst.query(command).strip()
+        self._check_pyvisa_status(command, custom_err_message=custom_err_message)
         return response
 
-    def check_pyvisa_status(self, command, custom_err_message=None):
+    def _check_pyvisa_status(self, command, custom_err_message=None):
         """Check the last status code of PyVISA
 
         Parameters
@@ -246,16 +274,19 @@ class FuncGen():
             If status returned by PyVISA write command is not
             `pyvisa.constants.StatusCode.success`
         """
-        status = self.inst.last_status
+        status = self._inst.last_status
         if not status == pyvisa.constants.StatusCode.success:
             if custom_err_message is not None:
-                msg = ("Could not {}: pyvisa returned StatusCode {} "
-                       "({})".format(custom_err_message, status, str(status)))
+                msg = (
+                    f"Could not {custom_err_message}: pyvisa returned "
+                    f"StatusCode {status} ({str(status)})"
+                )
                 raise RuntimeError(msg)
-            else:
-                msg = ("Writing/querying command {} failed: pyvisa returned StatusCode"
-                       " {} ({})".format(command, status, str(status)))
-                raise RuntimeError(msg)
+            msg = (
+                f"Writing/querying command {command} failed: pyvisa returned "
+                f"StatusCode {status} ({str(status)})"
+            )
+            raise RuntimeError(msg)
         return status
 
     def get_error(self):
@@ -268,7 +299,7 @@ class FuncGen():
         """
         return self.query("SYSTEM:ERROR:NEXT?")
 
-    def spawn_channel(self, channel, impedance):
+    def _spawn_channel(self, channel, impedance):
         """Wrapper function to create a `FuncGenChannel` object for
         a channel -- see the class docstring"""
         return FuncGenChannel(self, channel, impedance)
@@ -291,21 +322,22 @@ class FuncGen():
         # Find the necessary padding for the table columns
         # by evaluating the maximum length of the entries
         key_padding = max([len(key) for key in settings[0].keys()])
-        ch_paddings = [max([len(str(val[0])) for val in ch_settings.values()])
-                       for ch_settings in settings]
-        padding = [key_padding]+ch_paddings
-        print("\nCurrent settings for {} {} {}\n".format(self.maker,
-                                                         self.model,
-                                                         self.serial))
+        ch_paddings = [
+            max([len(str(val[0])) for val in ch_settings.values()])
+            for ch_settings in settings
+        ]
+        padding = [key_padding] + ch_paddings
+        print(f"\nCurrent settings for {self._maker} {self._model} {self._serial}\n")
         row_format = "{:>{padd[0]}s} {:{padd[1]}s} {:{padd[2]}s} {}"
-        table_header = row_format.format("Setting", "Ch1", "Ch2",
-                                         "Unit", padd=padding)
+        table_header = row_format.format("Setting", "Ch1", "Ch2", "Unit", padd=padding)
         print(table_header)
-        print("="*len(table_header))
-        for (ch1key, (ch1val, unit)), (_, (ch2val, _)) in zip(settings[0].items(),
-                                                              settings[1].items()):
-            print(row_format.format(ch1key, str(ch1val), str(ch2val),
-                                    unit, padd=padding))
+        print("=" * len(table_header))
+        for (ch1key, (ch1val, unit)), (_, (ch2val, _)) in zip(
+            settings[0].items(), settings[1].items()
+        ):
+            print(
+                row_format.format(ch1key, str(ch1val), str(ch2val), unit, padd=padding)
+            )
 
     def set_settings(self, settings):
         """Set the settings of both channels with settings dictionaries
@@ -358,23 +390,26 @@ class FuncGen():
         """
         if self.verbose:
             if state.lower() == "off" and not self.get_frequency_lock():
-                print("(!) {}: Tried to disable frequency lock, but "
-                      "frequency lock was not enabled".format(self.model))
+                print(
+                    f"(!) {self._model}: Tried to disable frequency lock, but "
+                    f"frequency lock was not enabled"
+                )
                 return
             if state.lower() == "on" and self.get_frequency_lock():
-                print("(!) {}: Tried to enable frequency lock, but "
-                      "frequency lock was already enabled".format(self.model))
+                print(
+                    f"(!) {self._model}: Tried to enable frequency lock, but "
+                    f"frequency lock was already enabled"
+                )
                 return
         # (Sufficient to disable for only one of the channels)
-        cmd = "SOURCE{}:FREQuency:CONCurrent {}".format(use_channel, state)
-        msg = "turn frequency lock {}".format(state)
+        cmd = f"SOURCE{use_channel}:FREQuency:CONCurrent {state}"
+        msg = f"turn frequency lock {state}"
         self.write(cmd, custom_err_message=msg)
 
     def software_trig(self):
         """NOT TESTED: sends a trigger signal to the device
         (for bursts or modulations)"""
         self.write("*TRG", custom_err_message="send trigger signal")
-
 
     ## ~~~~~~~~~~~~~~~~~~~~~ CUSTOM WAVEFORM FUNCTIONS ~~~~~~~~~~~~~~~~~~~~~ ##
 
@@ -387,7 +422,7 @@ class FuncGen():
             Strings with the names of the user functions that are not empty
         """
         catalogue = self.query("DATA:CATalog?").split(",")
-        catalogue = [wf[1:-1] for wf in catalogue] # strip off extra quotes
+        catalogue = [wf[1:-1] for wf in catalogue]  # strip off extra quotes
         return catalogue
 
     def get_custom_waveform(self, memory_num):
@@ -406,27 +441,31 @@ class FuncGen():
         """
         # Find the wavefroms in use
         waveforms_in_use = self.get_waveform_catalogue()
-        if "USER{}".format(memory_num) in waveforms_in_use:
+        if f"USER{memory_num}" in waveforms_in_use:
             # Copy the waveform to edit memory
-            self.write("DATA:COPY EMEMory,USER{}".format(memory_num))
+            self.write(f"DATA:COPY EMEMory,USER{memory_num}")
             # Get the length of the waveform
             waveform_length = int(self.query("DATA:POINts? EMEMory"))
             # Get the waveform (returns binary values)
-            waveform = self.inst.query_binary_values("DATA:DATA? EMEMory",
-                                                     datatype='H',
-                                                     is_big_endian=True,
-                                                     container=np.ndarray)
-            msg = ("Waveform length from native length command (DATA:POINts?) "
-                   "and the processed binary values do not match, {} and {} "
-                   "respectively".format(waveform_length, len(waveform)))
+            waveform = self._inst.query_binary_values(
+                "DATA:DATA? EMEMory",
+                datatype="H",
+                is_big_endian=True,
+                container=np.ndarray,
+            )
+            msg = (
+                f"Waveform length from native length command (DATA:POINts?) "
+                f"and the processed binary values do not match, "
+                f"{waveform_length} and {len(waveform)} respectively"
+            )
             assert len(waveform) == waveform_length, msg
             return waveform
-        else:
-            print("Waveform USER{} is not in use".format(memory_num))
-            return np.array([])
+        print(f"Waveform USER{memory_num} is not in use")
+        return np.array([])
 
-    def set_custom_waveform(self, waveform, normalise=True, memory_num=0,
-                            verify=True, print_progress=True):
+    def set_custom_waveform(
+        self, waveform, normalise=True, memory_num=0, verify=True, print_progress=True
+    ):
         """Transfer waveform data to edit memory and then user memory.
         NOTE: Will overwrite without warnings
 
@@ -460,53 +499,59 @@ class FuncGen():
         # Check if waveform data is suitable
         if print_progress:
             print("Check if waveform data is suitable..", end=" ")
-        self.check_arb_waveform_length(waveform)
+        self._check_arb_waveform_length(waveform)
         try:
-            self.check_arb_waveform_type_and_range(waveform)
-        except ValueError as e:
+            self._check_arb_waveform_type_and_range(waveform)
+        except ValueError as err:
             if print_progress:
-                print("\n  "+str(e))
+                print(f"\n  {err}")
                 print("Trying again normalising the waveform..", end=" ")
-            waveform = self.normalise_to_waveform(waveform)
+            waveform = self._normalise_to_waveform(waveform)
         if print_progress:
             print("ok")
             print("Transfer waveform to function generator..", end=" ")
         # Transfer waveform
-        self.inst.write_binary_values("DATA:DATA EMEMory,", waveform,
-                                      datatype='H', is_big_endian=True)
+        self._inst.write_binary_values(
+            "DATA:DATA EMEMory,", waveform, datatype="H", is_big_endian=True
+        )
         # Check for errors and check lengths are matching
         transfer_error = self.get_error()
         emem_wf_length = self.query("DATA:POINts? EMEMory")
-        if emem_wf_length == '' or not int(emem_wf_length) == len(waveform):
-            msg = ("Waveform in temporary EMEMory has a length of {}, not of "
-                   "the same length as the waveform ({}).\nError from the "
-                   "instrument: {}".format(emem_wf_length, len(waveform),
-                                           transfer_error))
+        if emem_wf_length == "" or not int(emem_wf_length) == len(waveform):
+            msg = (
+                f"Waveform in temporary EMEMory has a length of {emem_wf_length}"
+                f", not of the same length as the waveform ({len(waveform)})."
+                f"\nError from the instrument: {transfer_error}"
+            )
             raise RuntimeError(msg)
         if print_progress:
             print("ok")
-            print("Copy waveform to USER{}..".format(memory_num), end=" ")
-        self.write("DATA:COPY USER{},EMEMory".format(memory_num))
+            print(f"Copy waveform to USER{memory_num}..", end=" ")
+        self.write(f"DATA:COPY USER{memory_num},EMEMory")
         if print_progress:
             print("ok")
         if verify:
             if print_progress:
-                print("Verify waveform USER{}..".format(memory_num))
-            if "USER{}".format(memory_num) in self.get_waveform_catalogue():
-                self.verify_waveform(waveform, memory_num, normalise=normalise,
-                                     print_result=print_progress)
+                print(f"Verify waveform USER{memory_num}..")
+            if f"USER{memory_num}" in self.get_waveform_catalogue():
+                self._verify_waveform(
+                    waveform,
+                    memory_num,
+                    normalise=normalise,
+                    print_result=print_progress,
+                )
             else:
-                print("(!) USER{} is empty".format(memory_num))
+                print(f"(!) USER{memory_num} is empty")
         return waveform
 
-    def normalise_to_waveform(self, shape):
+    def _normalise_to_waveform(self, shape):
         """Normalise a shape of any discretisation and range to a waveform that
         can be transmitted to the function generator
 
         .. note::
             If you are transferring a flat/constant waveform, do not use this
             normaisation function. Transfer a waveform like
-            `int(self.arbitrary_waveform_resolution/2)*np.ones(2).astype(np.int32)`
+            `int(self._arbitrary_waveform_resolution/2)*np.ones(2).astype(np.int32)`
             without normalising for a well behaved flat function.
 
         Parameters
@@ -521,15 +566,14 @@ class FuncGen():
             Waveform as ints spanning the resolution of the function gen
         """
         # Check if waveform data is suitable
-        self.check_arb_waveform_length(shape)
+        self._check_arb_waveform_length(shape)
         # Normalise
         waveform = shape - np.min(shape)
         normalisation_factor = np.max(waveform)
-        waveform = waveform/normalisation_factor*self.arbitrary_waveform_resolution
+        waveform = waveform / normalisation_factor * self._arbitrary_waveform_resolution
         return waveform.astype(np.uint16)
 
-    def verify_waveform(self, waveform, memory_num, normalise=True,
-                        print_result=True):
+    def _verify_waveform(self, waveform, memory_num, normalise=True, print_result=True):
         """Compare a waveform in user memory to argument waveform
 
         Parameters
@@ -551,17 +595,19 @@ class FuncGen():
             List of the indices where the waveforms are not equal or `None` if
             the waveforms were of different lengths
         """
-        if normalise: # make sure test waveform is normalised
-            waveform = self.normalise_to_waveform(waveform)
+        if normalise:  # make sure test waveform is normalised
+            waveform = self._normalise_to_waveform(waveform)
         # Get the waveform on the instrument
         instrument_waveform = self.get_custom_waveform(memory_num)
         # Compare lengths
         len_inst_wav, len_wav = len(instrument_waveform), len(waveform)
         if not len_inst_wav == len_wav:
             if print_result:
-                print("The waveform in USER{} and the compared waveform are "
-                      "not of same length (instrument {} vs {})"
-                      "".format(memory_num, len_inst_wav, len_wav))
+                print(
+                    f"The waveform in USER{memory_num} and the compared "
+                    f"waveform are not of same length (instrument "
+                    f"{len_inst_wav} vs {len_wav})"
+                )
             return False, instrument_waveform, None
         # Compare each element
         not_equal = []
@@ -569,17 +615,21 @@ class FuncGen():
             if not instrument_waveform[i] == waveform[i]:
                 not_equal.append(i)
         # Return depending of whether list is empty or not
-        if not not_equal: # if list is empty
+        if not not_equal:  # if list is empty
             if print_result:
-                print("The waveform in USER{} and the compared waveform "
-                      "are equal".format(memory_num))
+                print(
+                    f"The waveform in USER{memory_num} and the compared "
+                    f"waveform are equal"
+                )
             return True, instrument_waveform, not_equal
         if print_result:
-            print("The waveform in USER{} and the compared waveform are "
-                  "NOT equal".format(memory_num))
+            print(
+                f"The waveform in USER{memory_num} and the compared "
+                f"waveform are NOT equal"
+            )
         return False, instrument_waveform, not_equal
 
-    def check_arb_waveform_length(self, waveform):
+    def _check_arb_waveform_length(self, waveform):
         """Checks if waveform is within the acceptable length
 
         Parameters
@@ -592,14 +642,17 @@ class FuncGen():
         ValueError
             If the waveform is not within the permitted length
         """
-        if ((len(waveform) < self.arbitrary_waveform_length[0]) or
-            (len(waveform) > self.arbitrary_waveform_length[1])):
-            msg = ("The waveform is of length {}, which is not within the "
-                   "acceptable length {} < len < {}"
-                   "".format(len(waveform), *self.arbitrary_waveform_length))
+        if (len(waveform) < self._arbitrary_waveform_length[0]) or (
+            len(waveform) > self._arbitrary_waveform_length[1]
+        ):
+            msg = (
+                "The waveform is of length {}, which is not within the "
+                "acceptable length {} < len < {}"
+                "".format(len(waveform), *self._arbitrary_waveform_length)
+            )
             raise ValueError(msg)
 
-    def check_arb_waveform_type_and_range(self, waveform):
+    def _check_arb_waveform_type_and_range(self, waveform):
         """Checks if waveform is of int/np.int32 type and within the resolution
         of the function generator
 
@@ -616,16 +669,20 @@ class FuncGen():
         """
         for value in waveform:
             if not isinstance(value, (int, np.uint16, np.int32)):
-                raise ValueError("The waveform contains values that are not"
-                                 "int, np.uint16 or np.int32")
-            if (value < 0) or (value > self.arbitrary_waveform_resolution):
-                raise ValueError("The waveform contains values out of range "
-                                 "({} is not within the resolution "
-                                 "[0, {}])".format(value,
-                                        self.arbitrary_waveform_resolution))
+                raise ValueError(
+                    "The waveform contains values that are not"
+                    "int, np.uint16 or np.int32"
+                )
+            if (value < 0) or (value > self._arbitrary_waveform_resolution):
+                raise ValueError(
+                    f"The waveform contains values out of range "
+                    f"({value} is not within the resolution "
+                    f"[0, {self._arbitrary_waveform_resolution}])"
+                )
 
 
 ## ~~~~~~~~~~~~~~~~~~~~~~~ CHANNEL CLASS ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ##
+
 
 class FuncGenChannel:
     """Class for controlling a channel on a function generator object
@@ -642,35 +699,34 @@ class FuncGenChannel:
 
     Attributes
     ----------
-    fgen : `FuncGen`
+    _fgen : `FuncGen`
         The function generator object for which the channel exists
     channel : {1, 2}
         The channel number
     impedance : {"50ohm", "highZ"}
         Determines voltage limits associated with high impedance (whether the
         instrument is using 50ohm or high Z cannot be controlled through VISA)
-    source : str
+    _source : str
         "SOURce{}:" where {} is the channel number
     settings_units : list
         The units for the settings produced by `FuncGenChannel.get_settings`
-    state_str : dict
+    _state_to_str : dict
         For conversion from states 1 and 2 to "ON" and "OFF"
     """
 
     # Attributes
-    state_str = {"1": "ON", "0": "OFF",
-                  1 : "ON",  0 : "OFF"}
+    _state_to_str = {"1": "ON", "0": "OFF", 1: "ON", 0: "OFF"}
     """Dictionary for converting output states to "ON" and "OFF" """
 
     def __init__(self, fgen, channel, impedance):
-        self.fgen = fgen
+        self._fgen = fgen
         self.channel = channel
-        self.source = "SOURce{}:".format(channel)
+        self._source = f"SOURce{channel}:"
         self.impedance = impedance
         # Adopt limits dictionary from instrument
-        self.channel_limits = copy.deepcopy(self.fgen.instrument_limits)
+        self.channel_limits = copy.deepcopy(self._fgen.instrument_limits)
 
-    def impedance_dependent_limit(self, limit_type):
+    def _impedance_dependent_limit(self, limit_type):
         """Check if the limit type is impedance dependent (voltages) or
         not (frequency)
 
@@ -679,43 +735,44 @@ class FuncGenChannel:
         bool
             `True` if the limit is impedance dependent
         """
-        try: # to access the key "min" to check if impedance must be selected
+        try:  # to access the key "min" to check if impedance must be selected
             _ = self.channel_limits[limit_type][0]["min"]
             return False
-        except KeyError: # if the key does not exist
+        except KeyError:  # if the key does not exist
             # The impedance must be selected
             return True
 
     def set_stricter_limits(self):
         """Set limits for the voltage and frequency limits of the channel output
         through a series of prompts"""
-        print("Set stricter voltage and frequency limits "
-              "for channel {}".format(self.channel))
+        print(
+            f"Set stricter voltage and frequency limits "
+            f"for channel {self.channel}"
+        )
         print("Use enter only to leave a limit unchanged.")
         # Go through the different limits in the instrument_limits dict
-        for limit_type, (inst_limit_dict, unit) in self.fgen.instrument_limits.items():
-            use_impedance = self.impedance_dependent_limit(limit_type)
+        for limit_type, (inst_limit_dict, unit) in self._fgen.instrument_limits.items():
+            use_impedance = self._impedance_dependent_limit(limit_type)
             print("Set {} in {}".format(limit_type, unit), end=" ")
             if use_impedance:
                 inst_limit_dict = inst_limit_dict[self.impedance]
-                print("[{} impedance limit]".format(self.impedance))
+                print(f"[{self.impedance} impedance limit]")
             else:
-                print("") # get new line
+                print("")  # get new line
             # Go through the min and max for the limit type
             for key, inst_value in inst_limit_dict.items():
                 # prompt for new value
-                new_value = input("  {} (instrument limit {}{}): "
-                                  "".format(key, inst_value, unit))
+                new_value = input(f"  {key} (instrument limit {inst_value}{unit}): ")
                 if new_value == "":
                     # Do not change if empty
                     print("\tLimit not changed")
                 else:
-                    try: # to convert to float
+                    try:  # to convert to float
                         new_value = float(new_value)
                     except ValueError:
-                        print("\tLimit unchanged: Could not convert \'{}\' "
-                              "to float".format(new_value))
-                        continue # to next item in dict
+                        print(f"\tLimit unchanged: Could not convert '{new_value}' "
+                              f"to float")
+                        continue  # to next item in dict
                     # Set the new limit
                     self.set_limit(limit_type, key, new_value, verbose=True)
 
@@ -741,10 +798,10 @@ class FuncGenChannel:
             `True` if new limit set, `False` otherwise
         """
         # Short hand references
-        inst_limit_dict = self.fgen.instrument_limits[limit_type]
+        inst_limit_dict = self._fgen.instrument_limits[limit_type]
         channel_limit_dict = self.channel_limits[limit_type]
         # Find the instrument limit and unit
-        use_impedance = self.impedance_dependent_limit(limit_type)
+        use_impedance = self._impedance_dependent_limit(limit_type)
         if use_impedance:
             inst_value = inst_limit_dict[0][self.impedance][bound]
         else:
@@ -758,7 +815,7 @@ class FuncGenChannel:
             current_min = channel_limit_dict[0]["min"]
         larger_than_min = new_value > current_min
         acceptable_max = bound == "max" and new_value < inst_value and larger_than_min
-        if acceptable_min or acceptable_max: # within the limits
+        if acceptable_min or acceptable_max:  # within the limits
             # Set the new channel_limit, using the impedance depending on the
             # limit type. Beware that the shorthand cannot be used, as this
             # only changes the shorthand not the dictionary itself
@@ -767,57 +824,57 @@ class FuncGenChannel:
             else:
                 self.channel_limits[limit_type][0][bound] = new_value
             if verbose:
-                print("\tNew limit set {}{}".format(new_value, unit))
+                print(f"\tNew limit set {new_value}{unit}")
             return True
-        elif verbose: # print description of why the limit was not set
+        if verbose:  # print description of why the limit was not set
             if larger_than_min:
                 reason = "larger" if bound == "max" else "smaller"
-                print("\tNew limit NOT set: {}{unit} is {} than the instrument "
-                      "limit ({}{unit})".format(new_value, reason, inst_value,
-                                                unit=unit))
+                print(f"\tNew limit NOT set: {new_value}{unit} is {reason} than "
+                      f"the instrument limit ({inst_value}{unit})")
             else:
-                print("\tNew limit NOT set: {}{unit} is smaller than the "
-                      "current set minimum ({}{unit})".format(new_value,
-                                                              current_min,
-                                                              unit=unit))
+                print(f"\tNew limit NOT set: {new_value}{unit} is smaller than the "
+                      f"current set minimum ({current_min}{unit})")
         return False
 
     # Get currently used parameters from function generator
     def get_output_state(self):
         """Returns "0" for "OFF", "1" for "ON" """
-        return self.fgen.query("OUTPut{}:STATe?".format(self.channel))
+        return self._fgen.query(f"OUTPut{self.channel}:STATe?")
 
     def get_function(self):
         """Returns string of function name"""
-        return self.fgen.query("{}FUNCtion:SHAPe?".format(self.source))
+        return self._fgen.query(f"{self._source}FUNCtion:SHAPe?")
 
     def get_amplitude(self):
         """Returns peak-to-peak voltage in volts"""
-        return float(self.fgen.query("{}VOLTage:AMPLitude?".format(self.source)))
+        return float(self._fgen.query(f"{self._source}VOLTage:AMPLitude?"))
 
     def get_offset(self):
         """Returns offset voltage in volts"""
-        return float(self.fgen.query("{}VOLTage:OFFSet?".format(self.source)))
+        return float(self._fgen.query(f"{self._source}VOLTage:OFFSet?"))
 
     def get_frequency(self):
         """Returns frequency in Hertz"""
-        return float(self.fgen.query("{}FREQuency?".format(self.source)))
+        return float(self._fgen.query(f"{self._source}FREQuency?"))
 
     # Get limits set in the channel class
     def get_frequency_lims(self):
         """Returns list of min and max frequency limits"""
-        return [self.channel_limits["frequency lims"][0][key]
-                for key in ["min", "max"]]
+        return [self.channel_limits["frequency lims"][0][key] for key in ["min", "max"]]
 
     def get_voltage_lims(self):
         """Returns list of min and max voltage limits for the current impedance"""
-        return [self.channel_limits["voltage lims"][0][self.impedance][key]
-                for key in ["min", "max"]]
+        return [
+            self.channel_limits["voltage lims"][0][self.impedance][key]
+            for key in ["min", "max"]
+        ]
 
     def get_amplitude_lims(self):
         """Returns list of min and max amplitude limits for the current impedance"""
-        return [self.channel_limits["amplitude lims"][0][self.impedance][key]
-                for key in ["min", "max"]]
+        return [
+            self.channel_limits["amplitude lims"][0][self.impedance][key]
+            for key in ["min", "max"]
+        ]
 
     def get_settings(self):
         """Get the settings for the channel
@@ -829,11 +886,13 @@ class FuncGenChannel:
             function, amplitude, offset, and frequency and values tuples of
             the corresponding return and unit
         """
-        return {"output":    (self.state_str[self.get_output_state()], ""),
-                "function":  (self.get_function(),  ""),
-                "amplitude": (self.get_amplitude(), "Vpp"),
-                "offset":    (self.get_offset(),    "V"),
-                "frequency": (self.get_frequency(), "Hz")}
+        return {
+            "output": (self._state_to_str[self.get_output_state()], ""),
+            "function": (self.get_function(), ""),
+            "amplitude": (self.get_amplitude(), "Vpp"),
+            "offset": (self.get_offset(), "V"),
+            "frequency": (self.get_frequency(), "Hz"),
+        }
 
     def print_settings(self):
         """Print the settings currently in use for the channel (Recommended
@@ -844,8 +903,7 @@ class FuncGenChannel:
         print("\nCurrent settings for channel {}".format(self.channel))
         print("==============================")
         for key, (val, unit) in settings.items():
-            print("{:>{num_char}s} {} {}".format(key, val, unit,
-                                                 num_char=longest_key))
+            print("{:>{num_char}s} {} {}".format(key, val, unit, num_char=longest_key))
 
     def set_settings(self, settings):
         """Set the settings of the channel with a settings dictionary. Will
@@ -862,11 +920,11 @@ class FuncGenChannel:
         # combination of settings
         self.set_output_state("OFF")
         # Set settings according to dictionary
-        self.set_function(settings['function'][0])
-        self.set_amplitude(settings['amplitude'][0])
-        self.set_offset(settings['offset'][0])
-        self.set_frequency(settings['frequency'][0])
-        self.set_output_state(settings['output'][0])
+        self.set_function(settings["function"][0])
+        self.set_amplitude(settings["amplitude"][0])
+        self.set_offset(settings["offset"][0])
+        self.set_frequency(settings["frequency"][0])
+        self.set_output_state(settings["output"][0])
 
     def set_output_state(self, state):
         """Enables or diables the output of the channel
@@ -880,21 +938,22 @@ class FuncGenChannel:
         Raises
         ------
         NotSetError
-            If `self.fgen.verify_param_set` is `True` and the value after
+            If `self._fgen.verify_param_set` is `True` and the value after
             applying the set function does not match the value returned by the
             get function
         """
-        err_msg = "turn channel {} to state {}".format(self.channel, state)
-        self.fgen.write("OUTPut{}:STATe {}".format(self.channel, state),
-                                            custom_err_message=err_msg)
-        if self.fgen.verify_param_set:
+        err_msg = f"turn channel {self.channel} to state {state}"
+        self._fgen.write(
+            f"OUTPut{self.channel}:STATe {state}", custom_err_message=err_msg
+        )
+        if self._fgen.verify_param_set:
             actual_state = self.get_output_state()
             if not actual_state == state:
-                msg = ("Channel {} was not turned {}, it is {}.\n"
-                       "Error from the instrument: {}"
-                       "".format(self.channel, state,
-                                 self.state_str[actual_state],
-                                 self.fgen.get_error()))
+                msg = (
+                    f"Channel {self.channel} was not turned {state}, it is "
+                    f"{self._state_to_str[actual_state]}.\n"
+                    f"Error from the instrument: {self._fgen.get_error()}"
+                )
                 raise NotSetError(msg)
 
     def get_output(self):
@@ -923,21 +982,22 @@ class FuncGenChannel:
         Raises
         ------
         NotSetError
-            If `self.fgen.verify_param_set` is `True` and the value after
+            If `self._fgen.verify_param_set` is `True` and the value after
             applying the set function does not match the value returned by the
             get function
         """
-        cmd = "{}FUNCtion:SHAPe {}".format(self.source, shape)
-        self.fgen.write(cmd, custom_err_message="set function {}".format(shape))
-        if self.fgen.verify_param_set:
+        cmd = f"{self._source}FUNCtion:SHAPe {shape}"
+        self._fgen.write(cmd, custom_err_message=f"set function {shape}")
+        if self._fgen.verify_param_set:
             actual_shape = self.get_function()
             if not actual_shape == shape:
-                msg = ("Function {} was not set on channel {}, it is {}. "
-                       "Check that the function name is correctly spelt. "
-                       "Run set_function.__doc__ to see available shapes.\n"
-                       "Error from the instrument: {}"
-                       "".format(shape, self.channel, actual_shape,
-                                 self.fgen.get_error()))
+                msg = (
+                    f"Function {shape} was not set on channel {self.channel}, "
+                    f"it is {actual_shape}. Check that the function name is "
+                    f"correctly spelt. Look up `set_function.__doc__` to see "
+                    f"available shapes.\n Error from the instrument: "
+                    f"{self._fgen.get_error()}"
+                )
                 raise NotSetError(msg)
 
     def set_amplitude(self, amplitude):
@@ -952,56 +1012,62 @@ class FuncGenChannel:
         Raises
         ------
         NotSetError
-            If `self.fgen.verify_param_set` is `True` and the value after
+            If `self._fgen.verify_param_set` is `True` and the value after
             applying the set function does not match the value returned by the
             get function
         """
         # Check if keyword min or max is given
         if str(amplitude).lower() in ["min", "max"]:
-            unit = "" # no unit for MIN/MAX
+            unit = ""  # no unit for MIN/MAX
             # Look up what the limit is for this keyword
-            amplitude = self.channel_limits["amplitude lims"][0][self.impedance][str(amplitude).lower()]
+            amplitude = self.channel_limits["amplitude lims"][0][self.impedance][
+                str(amplitude).lower()
+            ]
         else:
             unit = "Vpp"
             # Check if the given amplitude is within the current limits
             min_ampl, max_ampl = self.get_amplitude_lims()
             if amplitude < min_ampl or amplitude > max_ampl:
-                msg = ("Could not set the amplitude {}{unit} as it is not "
-                       "within the amplitude limits set for the instrument "
-                       "[{}, {}]{unit}".format(amplitude, min_ampl, max_ampl,
-                                               unit=unit))
+                msg = (
+                    f"Could not set the amplitude {amplitude}{unit} as it "
+                    f"is not within the amplitude limits set for the instrument "
+                    f"[{min_ampl}, {max_ampl}]{unit}"
+                )
                 raise NotSetError(msg)
         # Check that the new amplitude will not violate voltage limits
         min_volt, max_volt = self.get_voltage_lims()
         current_offset = self.get_offset()
-        if (amplitude/2-current_offset < min_volt or
-            amplitude/2+current_offset > max_volt):
-            msg = ("Could not set the amplitude {}{unit} as the amplitude "
-                   "combined with the offset ({}V) will be outside the "
-                   "absolute voltage limits [{}, {}]{unit}"
-                   "".format(amplitude, current_offset, min_volt, max_volt,
-                             unit=unit))
+        if (
+            amplitude / 2 - current_offset < min_volt
+            or amplitude / 2 + current_offset > max_volt
+        ):
+            msg = (
+                f"Could not set the amplitude {amplitude}{unit} as the amplitude "
+                f"combined with the offset ({current_offset}V) will be outside the "
+                f"absolute voltage limits [{min_volt}, {max_volt}]{unit}"
+            )
             raise NotSetError(msg)
         # Set the amplitude
-        cmd = "{}VOLTage:LEVel {}{}".format(self.source, amplitude, unit)
-        err_msg = "set amplitude {}{}".format(amplitude, unit)
-        self.fgen.write(cmd, custom_err_message=err_msg)
+        cmd = f"{self._source}VOLTage:LEVel {amplitude}{unit}"
+        err_msg = f"set amplitude {amplitude}{unit}"
+        self._fgen.write(cmd, custom_err_message=err_msg)
         # Verify that the amplitude has been set
-        if self.fgen.verify_param_set:
+        if self._fgen.verify_param_set:
             actual_amplitude = self.get_amplitude()
             # Multiply with the appropriate factor according to SI prefix, or
             # if string is empty, use the value looked up from channel_limits earlier
             if not unit == "":
-                check_amplitude = amplitude*self.SI_prefix_to_factor(unit)
+                check_amplitude = amplitude * self.SI_prefix_to_factor(unit)
             else:
-                 check_amplitude = amplitude
+                check_amplitude = amplitude
             if not actual_amplitude == check_amplitude:
-                msg = ("Amplitude {}{} was not set on channel {}, it is "
-                       "{}Vpp. Check that the number is within the possible "
-                       "range and in the correct format.\nError from the "
-                       "instrument: {}"
-                       "".format(amplitude, unit, self.channel,
-                                 actual_amplitude, self.fgen.get_error()))
+                msg = (
+                    f"Amplitude {amplitude}{unit} was not set on channel "
+                    f"{self.channel}, it is {actual_amplitude}Vpp. Check that "
+                    f" the number is within the possible range and in the "
+                    f"correct format.\nError from the instrument: "
+                    f"{self._fgen.get_error()}"
+                )
                 raise NotSetError(msg)
 
     def set_offset(self, offset, unit="V"):
@@ -1016,37 +1082,40 @@ class FuncGenChannel:
         Raises
         ------
         NotSetError
-            If `self.fgen.verify_param_set` is `True` and the value after
+            If `self._fgen.verify_param_set` is `True` and the value after
             applying the set function does not match the value returned by the
             get function
         """
         # Check that the new offset will not violate voltage limits
         min_volt, max_volt = self.get_voltage_lims()
         current_amplitude = self.get_amplitude()
-        offset = self.SI_prefix_to_factor(unit)*offset
-        if (current_amplitude/2-offset < min_volt or
-            current_amplitude/2+offset > max_volt):
-            msg = ("Could not set the offset {}V as the offset combined "
-                   "with the amplitude ({}V) will be outside the absolute "
-                   "voltage limits [{}, {}]V".format(offset,
-                                                     current_amplitude,
-                                                     min_volt, max_volt)
+        offset = self.SI_prefix_to_factor(unit) * offset
+        if (
+            current_amplitude / 2 - offset < min_volt
+            or current_amplitude / 2 + offset > max_volt
+        ):
+            msg = (
+                f"Could not set the offset {offset}V as the offset combined "
+                f"with the amplitude ({current_amplitude}V) will be outside "
+                f"the absolute voltage limits [{min_volt}, {max_volt}]V"
+            )
             raise NotSetError(msg)
         # Set the offset
-        cmd = "{}VOLTage:LEVel:OFFSet {}{}".format(self.source, offset, unit)
-        err_msg = "set offset {}{}".format(offset, unit)
-        self.fgen.write(cmd, custom_err_message=err_msg)
+        cmd = f"{self._source}VOLTage:LEVel:OFFSet {offset}{unit}"
+        err_msg = f"set offset {offset}{unit}"
+        self._fgen.write(cmd, custom_err_message=err_msg)
         # Verify that the offset has been set
-        if self.fgen.verify_param_set:
+        if self._fgen.verify_param_set:
             actual_offset = self.get_offset()
             # Multiply with the appropriate factor according to SI prefix
-            check_offset = offset*self.SI_prefix_to_factor(unit)
+            check_offset = offset * self.SI_prefix_to_factor(unit)
             if not actual_offset == check_offset:
-                msg = ("Offset {}{} was not set on channel {}, it is {}V. "
-                       "Check that the number is within the possible range and "
-                       "in the correct format.\nError from the instrument: {}"
-                       "".format(offset, unit, self.channel, actual_offset,
-                                 self.fgen.get_error()))
+                msg = (
+                    f"Offset {offset}{unit} was not set on channel "
+                    f"{self.channel}, it is {actual_offset}V. Check that the "
+                    f"number is within the possible range and in the correct "
+                    f"format.\nError from the instrument: {self._fgen.get_error()}"
+                )
                 raise NotSetError(msg)
 
     def set_frequency(self, freq, unit="Hz"):
@@ -1061,45 +1130,47 @@ class FuncGenChannel:
         Raises
         ------
         NotSetError
-            If `self.fgen.verify_param_set` is `True` and the value after
+            If `self._fgen.verify_param_set` is `True` and the value after
             applying the set function does not match the value returned by the
             get function
         """
-        if str(freq).lower() in ["min", "max"]: # handle min and max keywords
-            unit = "" # no unit for MIN/MAX
+        if str(freq).lower() in ["min", "max"]:  # handle min and max keywords
+            unit = ""  # no unit for MIN/MAX
             # Look up what the limit is for this keyword
             freq = self.channel_limits["frequency lims"][0][str(freq).lower()]
         else:
             # Check if the given frequency is within the current limits
             min_freq, max_freq = self.get_frequency_lims()
-            freq = self.SI_prefix_to_factor(unit)*freq
+            freq = self.SI_prefix_to_factor(unit) * freq
             if freq < min_freq or freq > max_freq:
-                msg = ("Could not set the frequency {}Hz as it is not within "
-                       "the frequency limits set for the instrument [{}, {}]"
-                       "Hz".format(freq, min_freq, max_freq))
+                msg = (
+                    f"Could not set the frequency {freq}Hz as it is not "
+                    f"within the frequency limits set for the instrument "
+                    f"[{min_freq}, {max_freq}]Hz"
+                )
                 raise NotSetError(msg)
-        # Check that the new amplitude will not violate voltage limits
-        min_volt, max_volt = self.get_voltage_lims()
         # Set the frequency
-        self.fgen.write("{}FREQuency:FIXed {}{}".format(self.source, freq, unit),
-                            custom_err_message="set frequency {}{}".format(freq, unit))
+        self._fgen.write(
+            f"{self._source}FREQuency:FIXed {freq}{unit}",
+            custom_err_message=f"set frequency {freq}{unit}",
+        )
         # Verify that the amplitude has been set
-        if self.fgen.verify_param_set:
+        if self._fgen.verify_param_set:
             actual_freq = self.get_frequency()
             # Multiply with the appropriate factor according to SI prefix, or
             # if string is empty, use the value looked up from channel_limits earlier
             if not unit == "":
-                check_freq = freq*self.SI_prefix_to_factor(unit)
+                check_freq = freq * self.SI_prefix_to_factor(unit)
             else:
-                check_freq =  freq
+                check_freq = freq
             if not actual_freq == check_freq:
-                msg = ("Frequency {}{} was not set on channel {}, it is {}Hz. "
-                "Check that the number is within the possible range and in "
-                "the correct format.\nError from the instrument: {}"
-                "".format(freq, unit, self.channel, actual_freq,
-                            self.fgen.get_error()))
+                msg = (
+                    f"Frequency {freq}{unit} was not set on channel {self.channel}"
+                    f", it is {actual_freq}Hz. Check that the number is within "
+                    f"the possible range and in the correct format.\nError "
+                    f"from the instrument: {self._fgen.get_error()}"
+                )
                 raise NotSetError(msg)
-
 
     ## ~~~~~~~~~~~~~~~~~~~~~~~ AUXILLIARY ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ##
 
@@ -1120,7 +1191,7 @@ class FuncGenChannel:
             if the unit string is empty
         """
         # SI prefix to numerical value
-        SI_conversion = {"M":1e6, "k":1e3, "m":1e-3}
+        SI_conversion = {"M": 1e6, "k": 1e3, "m": 1e-3}
         try:  # using the unit's first character as key in the dictionary
             factor = SI_conversion[unit[0]]
         except KeyError:  # if the entry does not exist
@@ -1132,6 +1203,7 @@ class FuncGenChannel:
 
 ## ~~~~~~~~~~~~~~~~~~~~~~~~~~~ ERROR CLASSES ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ##
 
+
 class NotSetError(Exception):
     """Error for when a value cannot be written to the instrument"""
 
@@ -1142,19 +1214,20 @@ class NotCompatibleError(Exception):
 
 ## ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ EXAMPLES ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ##
 
+
 def example_basic_control(address):
     """Example showing how to connect, and the most basic control of the
     instrument parameters"""
     print("\n\n", example_basic_control.__doc__)
     with FuncGen(address) as fgen:
-      fgen.ch1.set_function("SIN")
-      fgen.ch1.set_frequency(25, unit="Hz")
-      fgen.ch1.set_offset(50, unit="mV")
-      fgen.ch1.set_amplitude(0.002)
-      fgen.ch1.set_output("ON")
-      fgen.ch2.set_output("OFF")
-      # Alternatively fgen.ch1.print_settings() to show from one channel only
-      fgen.print_settings()
+        fgen.ch1.set_function("SIN")
+        fgen.ch1.set_frequency(25, unit="Hz")
+        fgen.ch1.set_offset(50, unit="mV")
+        fgen.ch1.set_amplitude(0.002)
+        fgen.ch1.set_output("ON")
+        fgen.ch2.set_output("OFF")
+        # Alternatively fgen.ch1.print_settings() to show from one channel only
+        fgen.print_settings()
 
 
 def example_change_settings(address):
@@ -1199,48 +1272,50 @@ def example_changing_limits(address):
             print(err)
 
 
-def example_set_and_use_custom_waveform(fgen=None, address=None, channel=1,
-                                        plot_signal=True):
+def example_set_and_use_custom_waveform(
+    fgen=None, address=None, channel=1, plot_signal=True
+):
     """Example showing a waveform being created, transferred to the instrument,
     and applied to a channel"""
     print("\n\n", example_set_and_use_custom_waveform.__doc__)
     # Create a signal
-    x = np.linspace(0, 4*np.pi, 8000)
-    signal = np.sin(x)+x/5
-    if plot_signal: # plot the signal for visual control
+    x = np.linspace(0, 4 * np.pi, 8000)
+    signal = np.sin(x) + x / 5
+    if plot_signal:  # plot the signal for visual control
         import matplotlib.pyplot as plt
+
         plt.plot(signal)
         plt.show()
     # Create initialise fgen if it was not supplied
     if fgen is None:
         fgen = FuncGen(address)
-        close_fgen = True # specify that it should be closed at end of function
+        close_fgen = True  # specify that it should be closed at end of function
     else:
-        close_fgen = False # do not close the supplied fgen at end
+        close_fgen = False  # do not close the supplied fgen at end
     print("Current waveform catalogue")
     for i, wav in enumerate(fgen.get_waveform_catalogue()):
-        print("  {}: {}".format(i, wav))
+        print(f"  {i}: {wav}")
     # Transfer the waveform
     fgen.set_custom_waveform(signal, memory_num=5, verify=True)
     print("New waveform catalogue:")
     for i, wav in enumerate(fgen.get_waveform_catalogue()):
-        print("  {}: {}".format(i, wav))
-    print("Set new wavefrom to channel {}..".format(channel), end=" ")
-    fgen.channels[channel-1].set_output_state("OFF")
-    fgen.channels[channel-1].set_function("USER5")
+        print(f"  {i}: {wav}")
+    print(f"Set new wavefrom to channel {channel}..", end=" ")
+    fgen.channels[channel - 1].set_output_state("OFF")
+    fgen.channels[channel - 1].set_function("USER5")
     print("ok")
     # Print current settings
     fgen.get_settings()
-    if close_fgen: fgen.close()
+    if close_fgen:
+        fgen.close()
 
 
 ## ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ MAIN FUNCTION ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ##
 
-if __name__ == '__main__':
-    address = 'USB0::0x0699::0x0353::1731975::INSTR'
-    example_basic_control(address)
-    example_change_settings(address)
-    example_lock_frequencies(address)
-    example_changing_limits(address)
-    with FuncGen(address) as fgen:
+if __name__ == "__main__":
+    example_basic_control(_VISA_ADDRESS)
+    example_change_settings(_VISA_ADDRESS)
+    example_lock_frequencies(_VISA_ADDRESS)
+    example_changing_limits(_VISA_ADDRESS)
+    with FuncGen(_VISA_ADDRESS) as fgen:
         example_set_and_use_custom_waveform(fgen)


### PR DESCRIPTION
- Adding a prefix `_` to methods and functions suggesting they are private:
    - `FuncGen` methods
      - `_check_pyvisa_status()`
      - `_initialise_model_properties()`
      - `_normalise_to_waveform()`
      - `_verify_waveform()`
      - `_check_arb_waveform_length()`
      - `_check_arb_waveform_type_and_range()`
      - `_impedance_dependent_limit()`
      - `_spawn_channel()`
  - `FuncGen` attributes
      - `_id`
      - `_inst`
      - `address` -> `_visa_address`
      - `_arbitrary_waveform_length`
      - `_arbitrary_waveform_resolution`
      - `_override_compatibility`
      - `_timeout`
      - `_maker`
      - `_serial`
      - `_model`
    - `FuncGenChannel`
      - `_source`
      - `state_str` -> `_state_to_str`
- Moving `SI_prefix_to_factor()` out of the class, now a private module function
- Moving to `f""`-strings from `"".format()`